### PR TITLE
Automate backend deploy - Let's just use a script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# qa secrets and uneccesary to put in repo
+qa/cloud_sql_proxy
+qa/deploy.sh
+
 # Mac OS
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,5 @@ js:
 console:
 	docker exec -it djapi bash
 
-
+deploy:
+	bash qa/deploy.sh

--- a/django/cgproj/settings.py
+++ b/django/cgproj/settings.py
@@ -84,7 +84,19 @@ if os.getenv('GAE_APPLICATION', None):
     DATABASES = {
         'default': {
                 'ENGINE': 'django.db.backends.postgresql',
-                'HOST': '/cloudsql/cellular-virtue-277000:us-central1:cgtest',
+                'HOST': '/cloudsql/cellular-virtue-277000:us-central-1:cgtest',
+                'PORT': '5432',
+                'USER': 'postgres',
+                'NAME': 'postgres',
+                'PASSWORD': 'testpassword',
+                }
+        }
+elif os.getenv('SECRET_CAPSTONE_SCRIPT', None) == "1":
+    DATABASES = {
+        'default': {
+                'ENGINE': 'django.db.backends.postgresql',
+                'HOST': '127.0.0.1',
+                'PORT': '5432',
                 'USER': 'postgres',
                 'NAME': 'postgres',
                 'PASSWORD': 'testpassword',

--- a/django/cloudbuild.yaml
+++ b/django/cloudbuild.yaml
@@ -1,5 +1,0 @@
-steps:
-  - name: "gcr.io/cloud-builders/gcloud"
-    args: ["app", "deploy"]
-  timeout: "1600s"
-  


### PR DESCRIPTION
Resigning to a semi-automated solution for backend deploys. Idea is we use a simple command `make deploy` in the root of the repo, which will contain secrets. Hence the script itself is not including in this pull request. Script will do full deploy / migration in about 1 minute.

I'd like to share the script itself via Slack privately and use the same script for #82 . I like the idea of managing all secrets in one file and bash is flexible. This is open for discussion, many options for how we might want to handle that issue.

Download script from Slack and place in your qa folder. Script is heavily commented but tldr is:

First, this assumes you're connected to the correct project via gcloud CLI... This just isn't something worth the time to automate. Just make sure your gcloud active account and project are correct. Google has great docs on how to use their CLI, but I can help answer questions too, if any needs help.

OK, now that that assumption is taken care of, running `make deploy` will result in:

- do a gcloud deploy (NOTE: This requires manually confirming project, target and entering 'y'!)
- download proxy if needed, then run proxy
- run django server locally, talking to gcp instance via proxy
- run the migration via local django server

Bash is a bit difficult, so please ask if questions or suggestions.

Closes #52 