### PR TITLE
Upgrade yarn package for security

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -13,6 +13,7 @@
     "@react-navigation/native": "^5.5.0",
     "@react-navigation/stack": "^5.4.1",
     "expo": "~37.0.3",
+    "logkitty": "^0.7.1",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",

--- a/react-native/yarn.lock
+++ b/react-native/yarn.lock
@@ -4630,6 +4630,15 @@ logkitty@^0.6.0:
     dayjs "^1.8.15"
     yargs "^12.0.5"
 
+logkitty@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/logkitty/-/logkitty-0.7.1.tgz#8e8d62f4085a826e8d38987722570234e33c6aa7"
+  integrity sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==
+  dependencies:
+    ansi-fragments "^0.2.1"
+    dayjs "^1.8.15"
+    yargs "^15.1.0"
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -7373,7 +7382,7 @@ yargs@^12.0.5:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@^15.3.1:
+yargs@^15.1.0, yargs@^15.3.1:
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
   integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==


### PR DESCRIPTION
Not actually a big deal because this code is only running locally on our devices, but interesting that the GitHub system is this good.

Useful links I found worth putting in repo history:

- [Good breakdown](https://www.robertcooper.me/how-yarn-lock-files-work-and-upgrading-dependencies)
- [Official docs](https://classic.yarnpkg.com/en/docs/yarn-lock/)
- [More](https://classic.yarnpkg.com/blog/2016/11/24/lockfiles-for-all/), [docs](https://classic.yarnpkg.com/en/docs/cli/upgrade/)

Resolves #89 