### PR TITLE
Prereq 2 fix - No Yarn

### DIFF
--- a/qa/prereq-linux2.sh
+++ b/qa/prereq-linux2.sh
@@ -1,23 +1,22 @@
 #!/bin/bash
 
+set -x
+
 echo "$(tput setaf 2)Log: Beginning make install part 2 ...$(tput sgr 0)"
 
 cd "react-native/"
-npm install -g yarn
-npm install --global expo-cli
-yarn add expo
-yarn add @react-navigation/native
-yarn add --dev jest
+npm install expo-cli --global
+npm install @react-navigation/native
+npm install
+npm install expo --global
 
 expo install react-native-gesture-handler react-native-reanimated \
             react-native-screens react-native-safe-area-context \
             @react-native-community/masked-view
 
-
-
-# Could not find yarn option for newman
-npm install -g newman
-npm install
-
 export PATH=$PATH:~/.npm-global/bin
+
+cd..
+npm install expo-cli --global
+
 echo "Finished..."

--- a/qa/prereq-linux2.sh
+++ b/qa/prereq-linux2.sh
@@ -16,7 +16,7 @@ expo install react-native-gesture-handler react-native-reanimated \
 
 export PATH=$PATH:~/.npm-global/bin
 
-cd..
+cd ..
 npm install expo-cli --global
 
 echo "Finished..."


### PR DESCRIPTION
Alrighty, after a few attempts on some Ubuntu 20.04 runs, I finally got things to work with just the make commands. No more Yarn.

![image](https://user-images.githubusercontent.com/46763450/85916574-f7819280-b806-11ea-8bc4-fcc19616d6c9.png)

Don't know why install the expo-cli twice is necessary, but that is the only way I could get it to work. ¯\_(ツ)_/¯

Resolves #111 