### PR TITLE
Add toast notification for success or failure

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/stack": "^5.4.1",
     "axios": "^0.19.2",
     "expo": "~37.0.3",
+    "expo-image-manipulator": "~8.1.0",
     "expo-image-picker": "~8.1.0",
     "faker": "^4.1.0",
     "logkitty": "^0.7.1",
@@ -30,8 +31,8 @@
     "react-native-reanimated": "~1.7.0",
     "react-native-safe-area-context": "0.7.3",
     "react-native-screens": "~2.2.0",
-    "react-native-web": "~0.11.7",
-    "expo-image-manipulator": "~8.1.0"
+    "react-native-smart-tip": "^2.2.0",
+    "react-native-web": "~0.11.7"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -8,16 +8,14 @@ import { StyleSheet,
          TouchableOpacity,
          ScrollView,
          Dimensions,
-         ToastAndroid,
          Image,
-         Platform,
-         AlertIOS,
        } from "react-native";
 import { FontAwesome5 } from '@expo/vector-icons';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { useHeaderHeight } from '@react-navigation/stack';
 import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
+import { WToast } from 'react-native-smart-tip'
 
 import { windowHeight, windowWidth } from '../config/dimensions';
 import Center from '../components/Center';
@@ -137,11 +135,17 @@ const PostingCreationScreen = props => {
 
   // Displays a notification message, style dependent on platform
   const notifyMessage = msg => {
-    if (Platform.OS === 'android') {
-      ToastAndroid.show(msg, ToastAndroid.SHORT)
-    } else {
-      AlertIOS.alert(msg);
-    }
+    const toastOptions = {
+      data: msg,
+      textColor: Colors.light_shade4,
+      backgroundColor: Colors.dark_shade1,
+      position: WToast.position.CENTER,
+      duration: WToast.duration.SHORT,
+      position: WToast.position.CENTER,
+      // icon: <ActivityIndicator color='#fff' size={'large'}/>
+	  }
+
+    WToast.show(toastOptions)
   }
 
   // Navigates to the Home Screen stack when called


### PR DESCRIPTION
Add a toast notification to center of screen indicating success or
failure of Posting Creation.  Works on both iOS and Android.

Added dependency `react-native-smart-tip`

Closes #140