### PR TITLE
Input always visible (including iOS)

### DIFF
--- a/react-native/screens/LoginScreen.js
+++ b/react-native/screens/LoginScreen.js
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react';
 import { View,
+         KeyboardAvoidingView,
          Text,
          TextInput,
          Button,
@@ -41,7 +42,7 @@ const LoginScreen = props => {
           fadeDuration={ 300 }
         />
       </View>
-      <View style={styles.inputContainer}>
+      <KeyboardAvoidingView behavior={'padding'} style={styles.inputContainer}>
         <View style={styles.inputView}>
           <AntDesign
             name={'user'}
@@ -69,7 +70,7 @@ const LoginScreen = props => {
             onChangeText={text => setPasswordText(text)}
           />
         </View>
-      </View>
+      </KeyboardAvoidingView>
       <TouchableOpacity>
         <Text style={styles.forgotPasswordText}>Forgot Password?</Text>
       </TouchableOpacity>

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -3,6 +3,7 @@ import { StyleSheet,
          Text,
          TextInput,
          View,
+         KeyboardAvoidingView,
          Button,
          Switch,
          TouchableOpacity,
@@ -359,7 +360,7 @@ const PostingCreationScreen = props => {
                   <ActivityIndicator size='large' color={Colors.primary}/>
                 </View>
               : <>
-                  <View style={styles.inputContainer}>
+                  <KeyboardAvoidingView behavior={'padding'} style={styles.inputContainer}>
                     <View style={styles.inputView}>
                       <TextInput
                         style={styles.inputText}
@@ -371,7 +372,7 @@ const PostingCreationScreen = props => {
                         value={emailText}
                       />
                     </View>
-                  </View>
+                  </KeyboardAvoidingView>
                   <CustomButton
                     onPress={handlePostCreation}
                     style={{ marginBottom: 10, alignSelf: 'center'}}

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View,
+         KeyboardAvoidingView,
          Text,
          Button,
          TouchableOpacity,
@@ -160,7 +161,7 @@ const PostingDetailScreen = props => {
               </View>
             : <>
 
-                <View style={styles.inputContainer}>
+                <KeyboardAvoidingView behavior={'padding'} style={styles.inputContainer}>
                   <View style={styles.inputView}>
                     <TextInput
                       style={styles.inputText}
@@ -172,7 +173,7 @@ const PostingDetailScreen = props => {
                       value={emailText}
                     />
                   </View>
-                </View>
+                </KeyboardAvoidingView>
                 <CustomButton
                   style={styles.confirmButton}
                   onPress={() => {

--- a/react-native/screens/RegisterScreen.js
+++ b/react-native/screens/RegisterScreen.js
@@ -1,11 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { View,
+         KeyboardAvoidingView,
          Text,
          TextInput,
          Button,
          TouchableOpacity,
          StyleSheet,
          Image,
+         Platform
        } from 'react-native';
 import { AntDesign } from '@expo/vector-icons';
 
@@ -27,7 +29,7 @@ const RegisterScreen = props => {
   return(
     <View style={styles.screen}>
       <Text style={styles.logo}>Register</Text>
-      <View style={styles.inputContainer}>
+      <KeyboardAvoidingView behavior={'padding'} style={styles.inputContainer}>
         <View style={styles.inputView}>
           <AntDesign
             name={'mail'}
@@ -82,7 +84,7 @@ const RegisterScreen = props => {
     /* onChangeText={text => setPasswordText(text)} */
           />
         </View>
-      </View>
+      </KeyboardAvoidingView>
 
       <CustomButton
         style={styles.registerButton}


### PR DESCRIPTION
As stated in commit, behavior is currently padding for both OSes. Here are the examples of where I could find things looking slightly wonky. 

Top input field in focus on tiny droid:
![small_droid](https://user-images.githubusercontent.com/46763450/86537978-dcb6ba00-bea7-11ea-94e1-7dc98e049a84.png)

Modal title goes out of view, again on tiny droid (not sure if we actually care about this as much because the placeholder text also explains what to do):
![modal_title_gone](https://user-images.githubusercontent.com/46763450/86538041-5353b780-bea8-11ea-9d31-c9a5c2f223fc.png)

Note that this is a 3.4in screen Droid device, anything 4.7in or above looked just fine (vast majority of devices). I propose that we merge this now so iOS is easier to test and address the edge cases of style weirdness in a later issue.

Resolves #171 