### PR TITLE
Posting Creation Screen image resets now!

### DIFF
--- a/react-native/components/CustomImagePicker.js
+++ b/react-native/components/CustomImagePicker.js
@@ -11,9 +11,6 @@ import { windowHeight, windowWidth } from '../config/dimensions';
 const CustomImagePicker = (props) => {
     var selectedImage = props.getImage();
 
-
-    console.log('Custom Image Props:');
-    console.log({props});
     useEffect(() => {
         props.onSelectImage(selectedImage);
     }, [selectedImage]);

--- a/react-native/components/CustomImagePicker.js
+++ b/react-native/components/CustomImagePicker.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, } from 'react';
 import { View, Image, TouchableOpacity, Alert, StyleSheet } from 'react-native';
 
 import { FontAwesome5 } from '@expo/vector-icons';
@@ -8,9 +8,12 @@ import * as ImageManipulator from 'expo-image-manipulator';
 import { windowHeight, windowWidth } from '../config/dimensions';
 
 
-const CustomImagePicker = props => {
-  const [selectedImage, setSelectedImage] = useState(null);
+const CustomImagePicker = (props) => {
+    var selectedImage = props.getImage();
 
+
+    console.log('Custom Image Props:');
+    console.log({props});
     useEffect(() => {
         props.onSelectImage(selectedImage);
     }, [selectedImage]);
@@ -47,7 +50,7 @@ const CustomImagePicker = props => {
             { compress: 0.5 },
         )
 
-        setSelectedImage({uri: resizedImage.uri, type: 'image/jpeg', name: imageName});
+        props.setImage({uri: resizedImage.uri, type: 'image/jpeg', name: imageName});
     };
 
     // Handles letting the user select an image from their library
@@ -80,7 +83,7 @@ const CustomImagePicker = props => {
             { compress: 0.5 },
         )
 
-        setSelectedImage({uri: resizedImage.uri, type: 'image/jpeg', name: imageName});
+        props.setImage({uri: resizedImage.uri, type: 'image/jpeg', name: imageName});
     };
 
     const selectImageOption = () => {
@@ -108,7 +111,7 @@ const CustomImagePicker = props => {
     return(
         <TouchableOpacity onPress={selectImageOption}>
 
-          { selectedImage
+          { selectedImage 
             ? <Image source={{ uri: selectedImage.uri }} style={styles.image} />
             : <FontAwesome5
                 size={150}
@@ -118,7 +121,7 @@ const CustomImagePicker = props => {
 
         </TouchableOpacity>
     );
-}
+};
 
 const styles = StyleSheet.create({
     image: {

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -54,6 +54,10 @@ const PostingCreationScreen = props => {
     }
   };
 
+  const getImage = () => {
+    return selectedImage
+  };
+
   // Create the data object in correct format to be sent off the server
   const createFormData = () => {
     const categoryValue = isCategorySwitchEnabled ? 'services' : 'goods';
@@ -101,6 +105,7 @@ const PostingCreationScreen = props => {
   const resetFormState = () => {
     setItemName('');
     setItemDescription('');
+    console.log('image gone? maybe?')
     setSelectedImage(null);
     setItemCount(1);
     setEmailText('');
@@ -160,6 +165,8 @@ const PostingCreationScreen = props => {
           <CustomImagePicker
             iconName='images'
             onSelectImage={selectImage}
+            getImage={getImage}
+            setImage={setSelectedImage}
           />
 
         </View>

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -105,7 +105,6 @@ const PostingCreationScreen = props => {
   const resetFormState = () => {
     setItemName('');
     setItemDescription('');
-    console.log('image gone? maybe?')
     setSelectedImage(null);
     setItemCount(1);
     setEmailText('');


### PR DESCRIPTION
Removed the `selectedImage` state from `CustomImagePicker.js`, as this was causing the image to stay after the post is uploaded (form reset is in `PostingCreationScreen.js`, which can't reset the state within `CustomImagePicker.js`, and it's that state that determines which image is displayed).

Instead, `PostingCreationScreen.js` passes functions via `props` to `CustomImagePicker.js`, which are used to alter and retrieve the value of PostingCreationScreen's `selectedImage` state

Tested on Android Emulator, unable to test iOS

Closes #185 