### PR TITLE
App engine flex deployed

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3
+FROM gcr.io/google-appengine/python
+
+RUN apt-get update && apt-get install -y binutils libproj-dev gdal-bin
 
 # Set environment variables
 ENV PYTHONUNBUFFERED 1
@@ -6,7 +8,7 @@ ENV PYTHONUNBUFFERED 1
 COPY requirements.txt /
 
 # Install dependencies.
-RUN pip install -r /requirements.txt
+RUN pip3 install -r /requirements.txt
 
 # Set work directory.
 RUN mkdir /code
@@ -15,4 +17,6 @@ WORKDIR /code
 # Copy project code.
 COPY . /code/
 
-EXPOSE 80
+EXPOSE 8080
+
+CMD python3 manage.py runserver 0.0.0.0:8080

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,6 +1,10 @@
-FROM gcr.io/google-appengine/python
+FROM python:3.8-slim-buster
 
-RUN apt-get update && apt-get install -y binutils libproj-dev gdal-bin
+RUN apt-get -y update && apt-get install -y binutils libproj-dev gdal-bin libpq-dev
+RUN export PATH=$PATH:/usr/lib
+RUN export PATH=$PATH:/usr/local/lib
+RUN export LD_LIBRARY_PATH=/usr/local/lib
+RUN echo `python3 --version`
 
 # Set environment variables
 ENV PYTHONUNBUFFERED 1

--- a/django/app.yaml
+++ b/django/app.yaml
@@ -3,7 +3,7 @@ env: flex
 entrypoint: "python3 manage.py runserver 0.0.0.0:8080"
 
 beta_settings:
-  cloud_sql_instances: "cellular-virtue-277000:us-central1:cg-prod=tcp:5432"
+  cloud_sql_instances: "ace-mote-270703:us-west1:squirtle=tcp:5432"
 
 runtime_config:
   python_version: 3

--- a/django/app.yaml
+++ b/django/app.yaml
@@ -1,6 +1,15 @@
-runtime: python37
+runtime: custom
+env: flex
+entrypoint: "python3 manage.py runserver 0.0.0.0:8080"
+
+beta_settings:
+  cloud_sql_instances: "ace-mote-270703:us-west1:charizard=tcp:5432"
+
+runtime_config:
+  python_version: 3
+
 handlers:
-- url: /static
-  static_dir: static/
-- url: /.*
-  script: auto
+  - url: /static
+    static_dir: static/
+  - url: /.*
+    script: auto

--- a/django/app.yaml
+++ b/django/app.yaml
@@ -3,7 +3,7 @@ env: flex
 entrypoint: "python3 manage.py runserver 0.0.0.0:8080"
 
 beta_settings:
-  cloud_sql_instances: "ace-mote-270703:us-west1:charizard=tcp:5432"
+  cloud_sql_instances: "cellular-virtue-277000:us-central1:cg-prod=tcp:5432"
 
 runtime_config:
   python_version: 3

--- a/django/cgapi/models.py
+++ b/django/cgapi/models.py
@@ -50,12 +50,12 @@ class Posting(models.Model):
 class UserProfile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, blank=True, null=True, related_name='profile')
     profile_text = models.CharField(max_length=160)
-    member_of = models.ManyToManyField(Community, related_name='members', blank=True, null=True)
+    member_of = models.ManyToManyField(Community, related_name='members', blank=True)
     home = models.ForeignKey(Community, on_delete=models.CASCADE, blank=True, null=True)
     phone_number = models.CharField(max_length=17, blank=True)
     created_on = models.DateField(default=date.today)
     profile_pic = models.ImageField(upload_to='uimg/', default='')
-    saved_postings = models.ManyToManyField(Posting, blank=True, null=True)
+    saved_postings = models.ManyToManyField(Posting, blank=True)
     is_admin = models.BooleanField(default=False)
     
     class Meta:

--- a/django/cgproj/settings.py
+++ b/django/cgproj/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+SECRET_KEY = 'sd1v^qwjvnb+4hd1tn0dy0#cl98mlfxez@69pno-^t3s$*2v4+'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -83,11 +83,11 @@ CORS_ORIGIN_ALLOW_ALL = True
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'HOST': '10.4.48.3',
+        'HOST': '10.63.0.7',
         'PORT': '5432',
         'USER': 'postgres',
         'NAME': 'postgres',
-        'PASSWORD': os.getenv('POSTGRES_DB_PASSWORD'),
+        'PASSWORD': 'testpassword',
         }
     }
 # Password validation

--- a/django/cgproj/settings.py
+++ b/django/cgproj/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'sd1v^qwjvnb+4hd1tn0dy0#cl98mlfxez@69pno-^t3s$*2v4+'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['cellular-virtue-277000.uc.r.appspot.com', 'localhost', '192.168.*', '10.*', '127.0.0.1']
+ALLOWED_HOSTS = ['ace-mote-270703.wl.r.appspot.com', 'localhost', '192.168.*', '10.*', '127.0.0.1']
 
 SECURE_SSL_REDIRECT = False
 
@@ -129,22 +129,17 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = 'static'
 
+DEFAULT_FILE_STORAGE = 'gcloud.GoogleCloudMediaFileStorage'
 
-if os.getenv('GAE_APPLICATION', None):
-    DEFAULT_FILE_STORAGE = 'gcloud.GoogleCloudMediaFileStorage'
-    
-    GS_PROJECT_ID = 'cellular-virtue-277000'
-    GS_MEDIA_BUCKET_NAME = 'cgapi-upload-media'
-    
+GS_PROJECT_ID = 'ace-mote-270703'
+GS_MEDIA_BUCKET_NAME = 'charmander'
 
-    MEDIA_URL = 'https://storage.googleapis.com/{}/'.format(GS_MEDIA_BUCKET_NAME)
-    MEDIA_ROOT = "media/"
-    
-    UPLOAD_ROOT = 'media/uploads/'
 
-else:
-    MEDIA_URL = '/media/'
-    MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = 'https://storage.googleapis.com/{}/'.format(GS_MEDIA_BUCKET_NAME)
+MEDIA_ROOT = "media/"
+
+UPLOAD_ROOT = 'media/uploads/'
+
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.sendgrid.net'

--- a/django/cgproj/settings.py
+++ b/django/cgproj/settings.py
@@ -20,12 +20,12 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'sd1v^qwjvnb+4hd1tn0dy0#cl98mlfxez@69pno-^t3s$*2v4+'
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["ace-mote-270703.wl.r.appspot.com", 'localhost', '192.168.*', '10.*', '127.0.0.1']
+ALLOWED_HOSTS = ['cellular-virtue-277000.uc.r.appspot.com', 'localhost', '192.168.*', '10.*', '127.0.0.1']
 
 SECURE_SSL_REDIRECT = False
 
@@ -83,11 +83,11 @@ CORS_ORIGIN_ALLOW_ALL = True
 DATABASES = {
     'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'HOST': '10.63.0.3',
+            'HOST': '10.4.48.3',
             'PORT': '5432',
             'USER': 'postgres',
             'NAME': 'postgres',
-            'PASSWORD': 'testpassword',
+            'PASSWORD': os.getenv('POSTGRES_DB_PASSWORD'),
             }
     }
 # Password validation

--- a/django/cgproj/settings.py
+++ b/django/cgproj/settings.py
@@ -10,6 +10,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
+# Python 3.8
+# build from source dependencies
+
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -35,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.gis',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
@@ -82,7 +86,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
         'HOST': '10.63.0.7',
         'PORT': '5432',
         'USER': 'postgres',

--- a/django/cgproj/settings.py
+++ b/django/cgproj/settings.py
@@ -20,14 +20,14 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+SECRET_KEY = 'sd1v^qwjvnb+4hd1tn0dy0#cl98mlfxez@69pno-^t3s$*2v4+'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["cellular-virtue-277000.uc.r.appspot.com", 'localhost', '192.168.*', '10.*']
+ALLOWED_HOSTS = ["ace-mote-270703.wl.r.appspot.com", 'localhost', '192.168.*', '10.*', '127.0.0.1']
 
-SECURE_SSL_REDIRECT = True
+SECURE_SSL_REDIRECT = False
 
 # Application definition
 
@@ -80,16 +80,16 @@ CORS_ORIGIN_ALLOW_ALL = True
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-if os.getenv('GAE_APPLICATION', None):
-    DATABASES = {
-        'default': {
-                'ENGINE': 'django.db.backends.postgresql',
-                'HOST': '/cloudsql/cellular-virtue-277000:us-central1:cgtest',
-                'USER': 'postgres',
-                'NAME': 'postgres',
-                'PASSWORD': os.getenv('POSTGRES_DB_PASSWORD'),
-                }
-        }
+DATABASES = {
+    'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'HOST': '10.63.0.3',
+            'PORT': '5432',
+            'USER': 'postgres',
+            'NAME': 'postgres',
+            'PASSWORD': 'testpassword',
+            }
+    }
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
 

--- a/django/cgproj/settings.py
+++ b/django/cgproj/settings.py
@@ -82,13 +82,13 @@ CORS_ORIGIN_ALLOW_ALL = True
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 DATABASES = {
     'default': {
-            'ENGINE': 'django.db.backends.postgresql',
-            'HOST': '10.4.48.3',
-            'PORT': '5432',
-            'USER': 'postgres',
-            'NAME': 'postgres',
-            'PASSWORD': os.getenv('POSTGRES_DB_PASSWORD'),
-            }
+        'ENGINE': 'django.db.backends.postgresql',
+        'HOST': '10.4.48.3',
+        'PORT': '5432',
+        'USER': 'postgres',
+        'NAME': 'postgres',
+        'PASSWORD': os.getenv('POSTGRES_DB_PASSWORD'),
+        }
     }
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,6 +1,6 @@
 Django
 djangorestframework
-psycopg2
+psycopg2-binary
 django-cors-headers
 pillow
 google-cloud-storage


### PR DESCRIPTION
Okey dokey, this appears to be working in my test GCP project. To be clear `10.4.48.3` is the Private IP addr of the DB instance cg-prod in GCP.

Things to note:

1. os.getenv() lines **ARE NOT WORKING** as is. I had to manually set the secret key and db password in my local copy of settings.py to get this deploy to work. I did not want to upload our secrets to GitHub again, so I left that out of the code.

 If you don't change manually, you will get a DJANGO_SECRET_KEY not set error or can't connect to DB error. I, for the life of me, could not figure out how to pass these two values through Dockerfile.... I tried many times. Whomever deploys will just have to set those vars locally, and we can fix this jenkyness in a future issue...

Also, remember that this Postgres DB has a new, secure password. Posted in Slack yesterday.

2. The `if os.getenv('GAE_APPLICATION', None):` trick does not work in App Engine flex, so I scrapped it. One database config.

3. Deployent should be performed with `gcloud beta app deploy` since we are now using beta features. Once deployed, one could watch log stream with `gcloud app logs tail -s default`.

4. Also once deployed, I would recommend running `./cloud_sql_proxy -instances=cellular-virtue-277000:us-central1:cg-prod=tcp:5432` then manually modifying DB hostname to 127.0.0.1 temporarily in order to run `python manage.py migrate` if need be.

After that I think everything would be good to go. Turned off SSL redirect because that was causing an issue as well. Honestly not sure how much that affects the project.

Made a slight adjustment to models as well, because I was getting warning that those `null`s were doing nothing when I migrated.

Not sure it fully resolves, but finishes a good chunk of #191.