### PR TITLE
Address iOS login crash

### DIFF
--- a/react-native/App.js
+++ b/react-native/App.js
@@ -6,6 +6,9 @@ import Routes from './navigation/Routes';
 import { AuthProvider } from './providers/AuthProvider';
 
 const App = () =>  {
+  // disable the yellow warning in-app, though they still appear in the console
+  console.disableYellowBox = true;
+
   const [isFontLoaded, setIsFontLoaded] = useState(false);
 
   // Load fonts and other assets before launching app

--- a/react-native/navigation/DrawerNav.js
+++ b/react-native/navigation/DrawerNav.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { ActivityIndicator } from 'react-native';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 
 import NavTabs from './NavTabs';
@@ -6,28 +7,38 @@ import AboutStack from './AboutStack';
 import UserPostingStack from './UserPostingStack';
 import DrawerContent from '../components/DrawerContent';
 
+import { AuthContext } from '../providers/AuthProvider';
+
 const Drawer = createDrawerNavigator();
 
 // Add screens to Drawer
 const DrawerNav = props => {
-  return(
-    <Drawer.Navigator
-      drawerContent={props => <DrawerContent {...props}/>}
-    >
-      <Drawer.Screen
-        name='Main'
-        component={NavTabs}
-      />
-      <Drawer.Screen
-        name='About'
-        component={AboutStack}
-      />
-      <Drawer.Screen
-        name='User Postings'
-        component={UserPostingStack}
-      />
-    </Drawer.Navigator>
-  );
+  const { isLoading } = useContext(AuthContext);
+  if (isLoading) {
+    return(
+      <ActivityIndicator size='large'/>
+    );
+  } else {
+
+    return(
+      <Drawer.Navigator
+        drawerContent={props => <DrawerContent {...props}/>}
+      >
+        <Drawer.Screen
+          name='Main'
+          component={NavTabs}
+        />
+        <Drawer.Screen
+          name='About'
+          component={AboutStack}
+        />
+        <Drawer.Screen
+          name='User Postings'
+          component={UserPostingStack}
+        />
+      </Drawer.Navigator>
+    );
+  }
 }
 
 export default DrawerNav;

--- a/react-native/navigation/HomeStack.js
+++ b/react-native/navigation/HomeStack.js
@@ -14,7 +14,10 @@ const HomeStack = props => {
   const { navigation } = props;
   const { user, username, communities } = useContext(AuthContext);
 
-  const homeCommunity = communities.find(community => community.id === user.profile.home);
+  let homeCommunity;
+  if (communities) {
+    homeCommunity = communities.find(community => community.id === user.profile.home);
+  }
 
   const PostingListScreenOptions = {
     // headerTitle: `Welcome ${username}`,

--- a/react-native/navigation/Routes.js
+++ b/react-native/navigation/Routes.js
@@ -16,7 +16,7 @@ import { AuthContext } from '../providers/AuthProvider';
 const Stack = createStackNavigator();
 
 const Routes = () => {
-    const { autoLogin, login, isLoading, token, hasProfile } = useContext(AuthContext);
+    const { autoLogin, isLoading, token, hasProfile } = useContext(AuthContext);
 
     // Check if the user is logged in
     useEffect(() => {

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -15,7 +15,6 @@
     "@react-navigation/drawer": "^5.8.2",
     "@react-navigation/native": "^5.5.0",
     "@react-navigation/stack": "^5.4.1",
-    "axios": "^0.19.2",
     "expo": "~37.0.3",
     "expo-image-manipulator": "~8.1.0",
     "expo-image-picker": "~8.1.0",

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -154,16 +154,18 @@ export const AuthProvider = props => {
         })
             .then(response => {
                 console.log("Response status: " + response.status);
-                return response.json();
+                if (response.status = 200) {
+                    return response.json();
+                } else {
+                    throw Error(response.statusText);
+                }
             })
             .then(json => {
                 console.log('Server Response: ' + JSON.stringify(json));
                 loginData = json;
                 fetchCommunities();
             })
-            .catch(error => {
-                console.log(error);
-            })
+            .catch(error => console.log(error))
             .finally(() => {
 
                 if (loginData) {
@@ -184,10 +186,10 @@ export const AuthProvider = props => {
         dispatch({ type: UPDATE_USER, updatedUser: newUserData });
     }
 
-    const handleAutoLogin = () => {
+    const handleAutoLogin = async () => {
         AsyncStorage.getItem('loginData').then(loginData => {
             console.log('Attempting to fetch token from AsyncStorage...');
-            if (loginData) {
+            if (loginData.token) {
                 loginData = JSON.parse(loginData);
                 console.log('Token exists! : ' + loginData.token);
                 console.log('User exists! : ' + loginData.user.username);

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -153,6 +153,7 @@ export const AuthProvider = props => {
         })
             .then(response => {
                 console.log("Response status: " + response.status);
+                fetchCommunities();
                 if (response.ok) {
                     return response.json();
                 } else {
@@ -163,11 +164,8 @@ export const AuthProvider = props => {
                 console.log('Server Response: ' + JSON.stringify(json));
                 if (json.Error) {
                     console.log("Error! " + requestType + " failed!");
-                    dispatch({ type: requestType, username: null, token: null, user: null});
-                    dispatch({ type: UPDATE_COMMUNITIES, communities: null });
                 } else {
                     loginData = json;
-                    fetchCommunities();
                     AsyncStorage.setItem('loginData', JSON.stringify(loginData)).then(() => {
                         dispatch({ type: requestType, username: userData.username, token: loginData.token, user: loginData});
                     }).catch(error => {
@@ -193,8 +191,8 @@ export const AuthProvider = props => {
                 loginData = JSON.parse(loginData);
                 console.log('Token exists! : ' + loginData.token);
                 console.log('User exists! : ' + loginData.user.username);
-                dispatch({ type: AUTO_LOGIN, token: loginData.token, username: loginData.user.username, user: loginData })
                 fetchCommunities();
+                dispatch({ type: AUTO_LOGIN, token: loginData.token, username: loginData.user.username, user: loginData })
             } else {
                 console.log('No existing token');
                 dispatch({ type: AUTO_LOGIN, token: null, username: null, user: null })

--- a/react-native/screens/LoginScreen.js
+++ b/react-native/screens/LoginScreen.js
@@ -90,7 +90,11 @@ const LoginScreen = props => {
             returnKeyType='done'
             secureTextEntry
             onChangeText={text => setPasswordText(text)}
-            onSubmitEditing={() => attemptLogin()}
+            onSubmitEditing={() => {
+              if (emailText && passwordText) {
+                attemptLogin();
+              }
+            }}
           />
         </View>
       </View>

--- a/react-native/screens/ProfileCreationScreen.js
+++ b/react-native/screens/ProfileCreationScreen.js
@@ -5,6 +5,7 @@ import {
     TextInput,
     Button,
     Picker,
+    ActivityIndicator,
     TouchableOpacity,
     ActionSheetIOS,
     KeyboardAvoidingView,
@@ -16,6 +17,7 @@ import { AuthContext } from '../providers/AuthProvider';
 
 import CustomImagePicker from '../components/CustomImagePicker';
 import CustomButton from '../components/CustomButton';
+import Center from '../components/Center';
 
 import Colors from '../config/colors';
 import { showModal, hideModal } from '../components/CustomModal';
@@ -25,7 +27,7 @@ const isAndroid = Platform.OS === 'android' ? true : false;
 
 const ProfileCreationScreen = props => {
     const { navigation } = props;
-    const { addProfile, updateUser, updateProfile, user, communities } = useContext(AuthContext);
+    const { isLoading, addProfile, updateUser, updateProfile, user, communities } = useContext(AuthContext);
 
 
     const [formValue, setFormValue] = useState(null);
@@ -205,64 +207,80 @@ const ProfileCreationScreen = props => {
         }
     };
 
-    return(
-        <View style={styles.screen}>
-          <Text style={styles.screenTitle}>Create Your Profile</Text>
+    const onKeyPress = (key) => {
+        if (key === 'Enter') {
+            profileTextRef.current.blur();
+        }
+    }
 
-          <View style={styles.imageContainer}>
-            <CustomImagePicker
-              iconName='images'
-              onSelectImage={selectImage}
-              getImage={getImage}
-              setImage={setSelectedImage}
-            />
-          </View>
+    if (isLoading) {
+        return( <Center><ActivityIndicator size='large'/></Center> );
+    } else {
+        return(
+            <View style={styles.screen}>
+              <Text style={styles.screenTitle}>Create Your Profile</Text>
 
-          <KeyboardAvoidingView style={styles.inputContainer} behavior='padding'>
-            <View style={styles.inputView}>
-              <TextInput
-                style={styles.inputText}
-                placeholder='First Name...'
-                placeholderTextColor={Colors.placeholder_text}
-                maxLength={25}
-                returnKeyType='next'
-                onChangeText={text => updateForm(text, 'first_name')}
-                ref={firstNameRef}
-              />
-            </View>
-            <View style={styles.inputView}>
-              <TextInput
-                style={styles.inputText}
-                placeholder='Last Name...'
-                placeholderTextColor={Colors.placeholder_text}
-                maxLength={25}
-                returnKeyType='next'
-                onChangeText={text => updateForm(text, 'last_name')}
-                ref={lastNameRef}
-              />
-            </View>
-            <View style={{ ...styles.inputView, ...styles.profileInputView}}>
-              <TextInput
-                style={styles.inputText}
-                placeholder='Profile Text...'
-                placeholderTextColor={Colors.placeholder_text}
-                maxLength={255}
-                multiline={true}
-                returnKeyType='go'
-                onChangeText={text => updateForm(text, 'profile_text')}
-                ref={profileTextRef}
-              />
-            </View>
-          </KeyboardAvoidingView>
+              <View style={styles.imageContainer}>
+                <CustomImagePicker
+                  iconName='images'
+                  onSelectImage={selectImage}
+                  getImage={getImage}
+                  setImage={setSelectedImage}
+                />
+              </View>
+
+              <KeyboardAvoidingView style={styles.inputContainer} behavior='padding'>
+                <View style={styles.inputView}>
+                  <TextInput
+                    style={styles.inputText}
+                    placeholder='First Name...'
+                    placeholderTextColor={Colors.placeholder_text}
+                    maxLength={25}
+                    returnKeyType='next'
+                    onChangeText={text => updateForm(text, 'first_name')}
+                    onSubmitEditing={() => {
+                        lastNameRef.current.focus()
+                    }}
+                    ref={firstNameRef}
+                  />
+                </View>
+                <View style={styles.inputView}>
+                  <TextInput
+                    style={styles.inputText}
+                    placeholder='Last Name...'
+                    placeholderTextColor={Colors.placeholder_text}
+                    maxLength={25}
+                    returnKeyType='next'
+                    onChangeText={text => updateForm(text, 'last_name')}
+                    onSubmitEditing={() => profileTextRef.current.focus()}
+                    ref={lastNameRef}
+                  />
+                </View>
+                <View style={{ ...styles.inputView, ...styles.profileInputView}}>
+                  <TextInput
+                    style={styles.inputText}
+                    placeholder='Profile Text...'
+                    placeholderTextColor={Colors.placeholder_text}
+                    maxLength={255}
+                    blurOnSubmit={true}
+                    multiline={true}
+                    returnKeyType='done'
+                    onChangeText={text => updateForm(text, 'profile_text')}
+                    onKeyPress={nativeEvent => onKeyPress(nativeEvent.key)}
+                    ref={profileTextRef}
+                  />
+                </View>
+              </KeyboardAvoidingView>
               { renderHomeCommunityPicker() }
-          <CustomButton
-            onPress={attemptProfileCreation}
-            style={{ marginBottom: 10, alignSelf: 'center'}}
-          >
-            <Text style={styles.buttonText}>Confirm</Text>
-          </CustomButton>
-        </View>
-    );
+              <CustomButton
+                onPress={attemptProfileCreation}
+                style={{ marginBottom: 10, alignSelf: 'center'}}
+              >
+                <Text style={styles.buttonText}>Confirm</Text>
+              </CustomButton>
+            </View>
+        );
+    }
 };
 
 const styles = StyleSheet.create({

--- a/react-native/screens/RegisterScreen.js
+++ b/react-native/screens/RegisterScreen.js
@@ -136,7 +136,11 @@ const RegisterScreen = props => {
             placeholderTextColor={Colors.placeholder_text}
             secureTextEntry
     /* onChangeText={text => setPasswordText(text)} */
-            onSubmitEditing={() => attemptRegister()}
+            onSubmitEditing={() => {
+              if (emailText && passwordText && userNameText) {
+                attemptRegister();
+              }
+            }}
           />
         </View>
       </View>


### PR DESCRIPTION
### Fixes:
1) Fix issue when trying to submit empty login/register form via button. Now it doesn't even attempt the request if the fields are empty.
2) (Hopefully) improves AuthProvider by resolving promises and not setting app ready state until communities are retrieved either from server or local storage.

### Enhancements: 
1) Adds Next button functionality to ProfileCreationScreen (forgot to add in previous pull request).

### Not addressed:
1) Issue with iOS app crashing when login/register attempts are unsuccessful. I don't know why this is happening. It doesn't happen on my Android phone or android emulator so it seems that it is an iOS only issue.  Will definitely need investigating.

addressed in issue #214