### PR TITLE
Erik edit postings

### DIFF
--- a/react-native/components/CustomModal.js
+++ b/react-native/components/CustomModal.js
@@ -27,6 +27,11 @@ const updatePostingOptions = {
     data: 'Updating your Posting...',
 };
 
+const deletePostingOptions = {
+    ...defaultOptions,
+    data: 'Deleting your Posting...',
+};
+
 const sendingEmailOptions = {
     ...defaultOptions,
     data: 'Sending Message...',
@@ -66,6 +71,9 @@ export function showModal(type) {
             break;
         case 'UPDATING_POSTING':
             options = updatePostingOptions;
+            break;
+        case 'DELETE_POSTING':
+            options = deletePostingOptions;
             break;
         case 'SENDING_EMAIL':
             options = sendingEmailOptions;

--- a/react-native/navigation/UserPostingStack.js
+++ b/react-native/navigation/UserPostingStack.js
@@ -10,7 +10,7 @@ import { headerOptions, drawerMenuIcon } from '../config/navigation-options';
 const Stack = createStackNavigator();
 
 const UserPostingStack = props => {
-    const { navigation } = props;
+    const { navigation, route } = props;
     const { user } = useContext(AuthContext);
 
     const UserPostingListScreenOptions = {

--- a/react-native/navigation/addPostingsRoutes.js
+++ b/react-native/navigation/addPostingsRoutes.js
@@ -19,8 +19,8 @@ export const addPostingsRoutes = (Stack, navigation) => {
               style={styles.headerRight}
               onPress={() => {
                   console.log(`Finish Editing ${route.params.id}`);
-                  if (route.params.submitSave) {
-                      route.params.submitSave.current();
+                  if (route.params.submitEditPosting) {
+                      route.params.submitEditPosting.current();
                   }
               }}
             >

--- a/react-native/navigation/addPostingsRoutes.js
+++ b/react-native/navigation/addPostingsRoutes.js
@@ -19,12 +19,12 @@ export const addPostingsRoutes = (Stack, navigation) => {
               style={styles.headerRight}
               onPress={() => {
                   console.log(`Finish Editing ${route.params.id}`);
-                  if (route.params.submit) {
-                      route.params.submit.current();
+                  if (route.params.submitSave) {
+                      route.params.submitSave.current();
                   }
               }}
             >
-            <Text style={styles.doneButtonText}>Done</Text>
+            <Text style={styles.saveButtonText}>Save</Text>
             </TouchableOpacity>
         );
     }
@@ -55,7 +55,7 @@ export const addPostingsRoutes = (Stack, navigation) => {
                   headerTitle: props => <CustomHeaderTitle request={route.params.request}/>,
                   ...headerOptions,
                   headerBackTitle: 'Back',
-                  headerRight: () => handleEdit(route),
+                  /* headerRight: () => handleEdit(route), */
                 })
             }
           />
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
   headerRight: {
     paddingRight: 15,
   },
-  doneButtonText: {
+  saveButtonText: {
     color: Colors.contrast1,
     fontSize: 20,
   },

--- a/react-native/navigation/addPostingsRoutes.js
+++ b/react-native/navigation/addPostingsRoutes.js
@@ -3,7 +3,6 @@ import { View, Text, Button, TouchableOpacity, Image, StyleSheet } from 'react-n
 import { Ionicons } from '@expo/vector-icons';
 import { HeaderBackButton } from '@react-navigation/stack';
 
-
 import PostingDetailScreen from '../screens/PostingDetailScreen';
 import EditPostingScreen from '../screens/EditPostingScreen';
 
@@ -56,7 +55,7 @@ export const addPostingsRoutes = (Stack, navigation) => {
                   headerTitle: props => <CustomHeaderTitle request={route.params.request}/>,
                   ...headerOptions,
                   headerBackTitle: 'Back',
-                  /* headerRight: () => handleEdit(route), */
+                  headerRight: () => handleEdit(route),
                 })
             }
           />
@@ -65,7 +64,8 @@ export const addPostingsRoutes = (Stack, navigation) => {
             component={EditPostingScreen}
             options={
               ({route, navigation}) => ({
-                headerTitle: `Editing ${route.params.id}`,
+                /* headerTitle: `Editing ${route.params.title}`, */
+                headerTitle: 'Edit Posting',
                 ...headerOptions,
                 headerRight: () => handleDone(route),
               })

--- a/react-native/screens/EditPostingScreen.js
+++ b/react-native/screens/EditPostingScreen.js
@@ -7,8 +7,11 @@ import { View,
          StyleSheet
        } from 'react-native';
 
+import { notifyMessage } from '../components/CustomToast';
+import { showModal, hideModal } from '../components/CustomModal';
 import Center from '../components/Center';
 import Colors from '../config/colors';
+import CustomImagePicker from '../components/CustomImagePicker';
 import { postings_url } from '../config/urls';
 
 const handleUpdatePosting = async (url, data) => {
@@ -33,20 +36,28 @@ const handleUpdatePosting = async (url, data) => {
           console.log(error.message)
       })
       .finally(() => {
+          hideModal();
+          notifyMessage('Posting Updated Successfully!');
       });
 };
 
 const EditPostingScreen = props => {
     const { route, navigation } = props;
-    const [selectedImage, setSelectedImage] = useState(null);
+
     const postingPatchUrl = postings_url + route.params.id + '/';
+
+    const [selectedImage, setSelectedImage] = useState(null);
+    const [isProcessing, setIsProcessing] = useState(false);
     const [formState, setFormState] = useState({
         title: route.params.title,
         desc: route.params.description,
     })
-    const submit = useRef(null);
 
-    submit.current = () => {
+    const submitSave = useRef(null);
+
+    submitSave.current = () => {
+        setIsProcessing(true);
+        showModal('UPDATING_POSTING');
 
         handleUpdatePosting(postingPatchUrl, createFormData()).then(() => {
             navigation.goBack();
@@ -54,7 +65,7 @@ const EditPostingScreen = props => {
     };
 
     useEffect(() => {
-        navigation.setParams({submit});
+        navigation.setParams({submitSave});
     }, []);
 
   const createFormData = () => {

--- a/react-native/screens/EditPostingScreen.js
+++ b/react-native/screens/EditPostingScreen.js
@@ -16,6 +16,7 @@ import { showModal, hideModal } from '../components/CustomModal';
 import Center from '../components/Center';
 import Colors from '../config/colors';
 import CustomImagePicker from '../components/CustomImagePicker';
+import CustomButton from '../components/CustomButton';
 import { postings_url } from '../config/urls';
 
 import { AuthContext } from '../providers/AuthProvider';
@@ -47,6 +48,24 @@ const handleUpdatePosting = async (url, data) => {
       });
 };
 
+const handleDeletePosting = async (url) => {
+    showModal('DELETE_POSTING');
+
+    return fetch(url, {
+        method: 'DELETE',
+    }).then(response => {
+        console.log(response.status);
+        return response.json();
+    }).then(json => {
+        // console.log(json);
+    }).catch(error => {
+        console.log(error.message);
+    }).finally(() => {
+        hideModal();
+        notifyMessage('Posting Deleted Successfully!');
+    });
+};
+
 const EditPostingScreen = props => {
     const { route, navigation } = props;
     const { communities } = useContext(AuthContext);
@@ -67,7 +86,6 @@ const EditPostingScreen = props => {
     const submitEditPosting = useRef(null);
 
     submitEditPosting.current = () => {
-        setIsProcessing(true);
         showModal('UPDATING_POSTING');
 
         handleUpdatePosting(postingPatchUrl, createFormData()).then(() => {
@@ -78,6 +96,11 @@ const EditPostingScreen = props => {
     useEffect(() => {
         navigation.setParams({submitEditPosting});
     }, []);
+
+    const submitDeletePosting = () => {
+        handleDeletePosting(postingPatchUrl);
+        navigation.navigate('Feed');
+    }
 
   const createFormData = () => {
     // const categoryValue = isCategorySwitchEnabled ? 'services' : 'goods';
@@ -184,6 +207,12 @@ const EditPostingScreen = props => {
               {route.params.description}
             </TextInput>
           { renderCommunityPicker() }
+          <CustomButton
+            onPress={() => submitDeletePosting()}
+            style={{ backgroundColor: Colors.contrast3, marginBottom: 10, alignSelf: 'center' }}
+          >
+            <Text style={styles.buttonText}>Delete Posting</Text>
+          </CustomButton>
           </View>
         </Center>
               </ScrollView>
@@ -232,6 +261,10 @@ const styles = StyleSheet.create({
     communityPicker: {
         height: 50,
         width: '80%',
+    },
+    buttonText: {
+        color: Colors.light_shade1,
+        fontSize: 24,
     },
 });
 

--- a/react-native/screens/EditPostingScreen.js
+++ b/react-native/screens/EditPostingScreen.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useLayoutEffect } from 'react';
 import { View,
          Text,
          TextInput,
@@ -9,20 +9,46 @@ import { View,
 
 import Center from '../components/Center';
 import Colors from '../config/colors';
+import { postings_url } from '../config/urls';
 
-async function apiCall(data) {
-    // make POST request with data
+const handleUpdatePosting = async (url, data) => {
+
+    console.log("Outgoing payload: " + JSON.stringify(data));
+
+    return fetch(url, {
+      method: 'PATCH',
+      headers: {
+        'content-type': 'multipart/form-data',
+      },
+      body: data,
+    })
+      .then(response => {
+          console.log(response.status);
+          return response.json();
+      })
+      .then(json => {
+          console.log(json);
+      })
+      .catch(error => {
+          console.log(error.message)
+      })
+      .finally(() => {
+      });
 };
 
 const EditPostingScreen = props => {
     const { route, navigation } = props;
-    const [formState, setFormState] = useState({});
-    const [bodyText, setBodyText] = useState(route.params.body);
+    const [selectedImage, setSelectedImage] = useState(null);
+    const postingPatchUrl = postings_url + route.params.id + '/';
+    const [formState, setFormState] = useState({
+        title: route.params.title,
+        desc: route.params.description,
+    })
     const submit = useRef(null);
 
     submit.current = () => {
-        // make API call with new form state
-        apiCall(formState).then(() => {
+
+        handleUpdatePosting(postingPatchUrl, createFormData()).then(() => {
             navigation.goBack();
         });
     };
@@ -31,26 +57,48 @@ const EditPostingScreen = props => {
         navigation.setParams({submit});
     }, []);
 
+  const createFormData = () => {
+    // const categoryValue = isCategorySwitchEnabled ? 'services' : 'goods';
+    // const requestValue = isRequestSwitchEnabled ? true : false;
+
+    const data = new FormData();
+
+    if (selectedImage) {
+      data.append('item_pic', selectedImage);
+    }
+
+      data.append('title', formState.title);
+      data.append('desc', formState.desc);
+    // data.append('count', itemCount);
+    // data.append('owner', user.user.id);
+    // data.append('category', categoryValue);
+    // data.append('request', requestValue);
+    // data.append('in_community', user.profile.home);
+
+    return data;
+  };
+
+    const updateForm = (text, input) => {
+        setFormState({ ...formState, [input]: text });
+    };
+
     return(
         <Center style={styles.screen}>
-          <Text style={styles.titleText}>
-              Edit Your Posting
-            </Text>
           <View style={styles.editContent}>
-            <Text style={styles.editBodyHeader}>Edit Title</Text>
+            <Text style={styles.editBodyHeader}>Title</Text>
             <TextInput
               style={styles.editTextInput}
-              onChangeText={text => setBodyText(text)}
+              onChangeText={text => updateForm(text, 'title')}
               multiline={true}
             >
               {route.params.title}
             </TextInput>
           </View>
           <View style={styles.editContent}>
-            <Text style={styles.editBodyHeader}>Edit Body</Text>
+            <Text style={styles.editBodyHeader}>Description</Text>
             <TextInput
               style={styles.editTextInput}
-              onChangeText={text => setBodyText(text)}
+              onChangeText={text => updateForm(text, 'desc')}
               multiline={true}
             >
               {route.params.description}

--- a/react-native/screens/EditPostingScreen.js
+++ b/react-native/screens/EditPostingScreen.js
@@ -84,6 +84,8 @@ const EditPostingScreen = props => {
     const placeholderImage = route.params.item_pic;
 
     const submitEditPosting = useRef(null);
+    const titleTextRef = useRef(null);
+    const descriptionTextRef = useRef(null);
 
     submitEditPosting.current = () => {
         showModal('UPDATING_POSTING');
@@ -133,7 +135,6 @@ const EditPostingScreen = props => {
     };
 
     const selectImage = imageData => {
-        console.log("In selectImage: " + JSON.stringify(imageData));
         setSelectedImage(imageData);
     };
 
@@ -154,6 +155,7 @@ const EditPostingScreen = props => {
                 </View>
             );
         } else {
+            return(null);
             // return(
             //     <View style={{...styles.inputView, flexDirection: 'column', height: 80, paddingVertical: 10}}>
             //       <Button
@@ -170,6 +172,12 @@ const EditPostingScreen = props => {
         return communities.map(community =>
             <Picker.Item label={community.name} value={community} key={community.id}/>
         );
+    }
+
+    const onKeyPress = (key) => {
+        if (key === 'Enter') {
+            descriptionInputRef.current.blur();
+        }
     }
 
     return(
@@ -192,7 +200,10 @@ const EditPostingScreen = props => {
             <TextInput
               style={styles.editTextInput}
               onChangeText={text => updateForm(text, 'title')}
-              multiline={true}
+              returnKeyType='next'
+              blurOnSubmit={false}
+              ref={titleTextRef}
+              onSubmitEditing={() => descriptionTextRef.current.focus()}
             >
               {route.params.title}
             </TextInput>
@@ -202,7 +213,10 @@ const EditPostingScreen = props => {
             <TextInput
               style={styles.editTextInput}
               onChangeText={text => updateForm(text, 'desc')}
+              blurOnSubmit={true}
+              onKeyPress={nativeEvent => onKeyPress(nativeEvent.key)}
               multiline={true}
+              ref={descriptionTextRef}
             >
               {route.params.description}
             </TextInput>
@@ -234,6 +248,7 @@ const styles = StyleSheet.create({
     editContent: {
         width: '100%',
         alignItems: 'center',
+        paddingVertical: 10,
     },
     editBodyHeader: {
         fontSize: 18,

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -93,7 +93,10 @@ const PostingDetailScreen = props => {
         <CustomButton
           style={styles.reachOutButton}
           onPress={() => {
-            console.log("edit posting clicked!");
+            console.log(navigation.navigate('EditPosting', {
+              ...route.params,
+            })
+            );
           }}
         >
           <Text style={styles.reachOutButtonText}>Edit Posting</Text>

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -93,10 +93,9 @@ const PostingDetailScreen = props => {
         <CustomButton
           style={styles.reachOutButton}
           onPress={() => {
-            console.log(navigation.navigate('EditPosting', {
+            navigation.navigate('EditPosting', {
               ...route.params,
             })
-            );
           }}
         >
           <Text style={styles.reachOutButtonText}>Edit Posting</Text>

--- a/react-native/screens/ProfileEditScreen.js
+++ b/react-native/screens/ProfileEditScreen.js
@@ -24,7 +24,6 @@ import { windowHeight, windowWidth } from '../config/dimensions';
 import { users_url, profiles_url } from '../config/urls';
 
 import { AuthContext } from '../providers/AuthProvider';
-
 const ProfileEditScreen = props => {
     const { navigation } = props;
     const { addProfile, updateUser, updateProfile, user, communities, checkUsername } = useContext(AuthContext);
@@ -221,7 +220,6 @@ const ProfileEditScreen = props => {
         lastNameRef.current.clear();
         profileTextRef.current.clear();
     };
-
 
     const getImage = () => {
         return selectedImage;

--- a/react-native/screens/ProfileEditScreen.js
+++ b/react-native/screens/ProfileEditScreen.js
@@ -226,7 +226,6 @@ const ProfileEditScreen = props => {
     };
 
     const selectImage = imageData => {
-        console.log("In selectImage: " + JSON.stringify(imageData));
         setSelectedImage(imageData);
     };
 


### PR DESCRIPTION
## Additions
1) Adds ability for user to edit their own postings, including deleting them.
If user navigates to the detail screen of one of their own postings, then the 'reach out' button is replaced with an 'edit posting' button. Clicking this takes the user to the Edit Posting Screen where they can currently edit the image, title, description and community it is in (community change currently only android).

## Still needs
1) Needs better styling
2) Add the rest of the fields that can be modified, such as request type, count and category.

## To Note
1) In order to see the changes, the user needs to navigate back to the Feed screen, pull to refresh the postings and then navigate back. Need to fix this so that the view updates immediately.  Issue #218 addresses this

closes #195 