### PR TITLE
Login / register fail modal in AuthProvider

### DIFF
--- a/react-native/components/CustomModal.js
+++ b/react-native/components/CustomModal.js
@@ -29,13 +29,13 @@ const updatePostingOptions = {
 
 const loginFailedOptions = {
     ...defaultOptions,
-    data: 'Login Failed!',
+    data: 'Login attempt failed!',
     icon: <MaterialIcons name='error-outline' size={50} color='red'/>,
 };
 
 const registerFailedOptions = {
     ...defaultOptions,
-    data: 'Register Failed!',
+    data: 'Registration attempt failed!',
     icon: <MaterialIcons name='error-outline' size={50} color='red'/>,
  };
 

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -13,6 +13,8 @@ const ADD_PROFILE = 'ADD_PROFILE';
 const UPDATE_PROFILE = 'UPDATE_PROFILE';
 const UPDATE_USER = 'UPDATE_USER';
 const UPDATE_COMMUNITIES = 'UPDATE_COMMUNITIES';
+const SET_AUTH_FAILED = 'SET_AUTH_FAILED';
+const RESET_AUTH_STATUS = 'RESET_AUTH_STATUS';
 
 // Provides token and login/logout functionality to Global App Context
 // Allows the app to know which user is using it and to handle login/logout
@@ -27,7 +29,7 @@ export const AuthProvider = props => {
         hasProfile: true,
         user: null,
         communities: null,
-        updated: false,
+        authFailed: false,
     };
 
     const loginReducer = (previousState, action) => {
@@ -93,6 +95,16 @@ export const AuthProvider = props => {
                     communities: action.communities,
                     isLoading: false,
                 };
+            case SET_AUTH_FAILED:
+                return {
+                    ...previousState,
+                    authFailed: true,
+                };
+            case RESET_AUTH_STATUS:
+                return {
+                    ...previousState,
+                    authFailed: false,
+                };
         }
     };
 
@@ -153,31 +165,30 @@ export const AuthProvider = props => {
             .then(response => {
                 console.log("Response status: " + response.status);
                 if (response.status != 200) {
-                    if (requestType == 'LOGIN') {
-                        showModal('LOGIN_FAILED');
-                        setTimeout(() => {
-                            hideModal();
-                        }, 3000);
-                    }
-                    else if (requestType == 'REGISTER') {
-                        showModal('REGISTER_FAILED');
-                        setTimeout(() => {
-                            hideModal();
-                        }, 3000);
-                    }
+                    // if (requestType == 'LOGIN') {
+                    //     showModal('LOGIN_FAILED');
+                    //     setTimeout(() => {
+                    //         hideModal();
+                    //     }, 3000);
+                    // }
+                    // else if (requestType == 'REGISTER') {
+                    //     showModal('REGISTER_FAILED');
+                    //     setTimeout(() => {
+                    //         hideModal();
+                    //     }, 3000);
+                    // }
+                    dispatch({ type: SET_AUTH_FAILED });
+                } else {
+                    return response.json();
                 }
-                return response.json();
             })
             .then(json => {
-                console.log('Server Response: ' + JSON.stringify(json));
-                loginData = json;
-                fetchCommunities();
-                setLoginData(loginData, requestType);
-            })
-            .catch(error => {
-                console.log(error);
-            })
-            .finally(() => {
+                if (json) {
+                    console.log('Server Response: ' + JSON.stringify(json));
+                    loginData = json;
+                    fetchCommunities();
+                    setLoginData(loginData, requestType);
+                }
             });
     };
 
@@ -259,6 +270,10 @@ export const AuthProvider = props => {
         dispatch({ type: SET_IS_LOADING, isLoading: loadingStatus });
     };
 
+    const resetAuthStatus = () => {
+        dispatch({ type: RESET_AUTH_STATUS });
+    };
+
     return (
         <AuthContext.Provider
           value={{
@@ -268,6 +283,8 @@ export const AuthProvider = props => {
               hasProfile: loginState.hasProfile,
               user: loginState.user,
               communities: loginState.communities,
+              authFailed: loginState.authFailed,
+              resetAuthStatus,
               updateProfile,
               updateUser,
               autoLogin: handleAutoLogin,

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useReducer, useContext } from 'react';
+import React, { createContext, useReducer } from 'react';
 import { AsyncStorage } from 'react-native';
 
 import { showModal, hideModal } from '../components/CustomModal';

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -161,7 +161,7 @@ export const AuthProvider = props => {
                     setTimeout(() => {
                         hideModal();
                         }, 1000);
-                }, 800);
+                }, 600);
                 throw "Auth_failed"
             } else {
                 return response.json();

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useReducer, useContext } from 'react';
 import { AsyncStorage } from 'react-native';
 
+import { showModal, hideModal } from '../components/CustomModal';
 import { login_url, register_url, check_username_url, communities_url } from '../config/urls';
 
 const AUTO_LOGIN = 'AUTO_LOGIN';
@@ -35,7 +36,6 @@ export const AuthProvider = props => {
                 return {
                     ...previousState,
                     token: action.token,
-                    // isLoading: false,
                     user: action.user,
                 };
             case LOGIN:
@@ -116,8 +116,6 @@ export const AuthProvider = props => {
                     },
                 }).then(response => response.json())
                   .then(communitiesJson => {
-                      // console.log("Fetching communities: ");
-                      // console.log(communitiesJson);
 
                       AsyncStorage.setItem('communities', JSON.stringify(communitiesJson)).then(() => {
                           dispatch({ type: UPDATE_COMMUNITIES, communities: communitiesJson });
@@ -154,18 +152,27 @@ export const AuthProvider = props => {
         })
             .then(response => {
                 console.log("Response status: " + response.status);
-                if (response.ok) {
-                    return response.json();
-                } else {
-                    throw Error('ERROR: ' + requestType + ' failed! ' + response.body);
+                if (response.status != 200) {
+                    if (requestType == 'LOGIN') {
+                        showModal('LOGIN_FAILED');
+                        setTimeout(() => {
+                            hideModal();
+                        }, 3000);
+                    }
+                    else if (requestType == 'REGISTER') {
+                        showModal('REGISTER_FAILED');
+                        setTimeout(() => {
+                            hideModal();
+                        }, 3000);
+                    }
                 }
+                return response.json();
             })
             .then(json => {
                 console.log('Server Response: ' + JSON.stringify(json));
                 loginData = json;
                 fetchCommunities();
                 setLoginData(loginData, requestType);
-
             })
             .catch(error => {
                 console.log(error);

--- a/react-native/screens/LoginScreen.js
+++ b/react-native/screens/LoginScreen.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useContext } from 'react';
+import React, { useEffect, useRef, useState, useContext } from 'react';
 import { View,
          Text,
          TextInput,
@@ -19,10 +19,11 @@ import { windowHeight, windowWidth } from '../config/dimensions';
 
 const LoginScreen = props => {
   const { navigation, route } = props;
-  const { login } = useContext(AuthContext);
+  const { login, authFailed, resetAuthStatus } = useContext(AuthContext);
 
   const passwordInputRef = useRef(null);
 
+<<<<<<< HEAD
   const attemptLogin = values => {
     showModal('LOADING');
     setTimeout(() => {
@@ -31,6 +32,43 @@ const LoginScreen = props => {
 
     const loginData = { username: values.username, password: values.password };
     login(loginData);
+=======
+  useEffect(() => {
+    console.log('Auth Failed? ' + authFailed);
+  }, [authFailed]);
+
+  const attemptLogin = () => {
+    if (!emailText || !passwordText) {
+      showModal('VALIDATION_ERROR');
+      setTimeout(() => {
+        hideModal();
+      }, 900);
+    } else {
+      const loginData = { username: emailText, password: passwordText };
+      login(loginData);
+
+      showModal('LOADING');
+      setTimeout(() => {
+        hideModal();
+        checkAuthFailed();
+      }, 1000);
+    }
+  };
+
+  const checkAuthFailed = () => {
+    // console.log('Auth Failed? ' + authFailed);
+    if (authFailed) {
+      showErrorModal();
+    }
+  }
+
+  const showErrorModal = () => {
+    showModal('LOGIN_FAILED');
+    setTimeout(() => {
+      hideModal();
+      resetAuthStatus();
+    }, 900);
+>>>>>>> Add authFailed var to Context and listen on it in Login Screen
   };
 
   const errorIcon = () => (
@@ -96,9 +134,13 @@ const LoginScreen = props => {
                 placeholderTextColor={Colors.placeholder_text}
                 returnKeyType='done'
                 secureTextEntry
+<<<<<<< HEAD
                 value={values.password}
                 onBlur={handleBlur('password')}
                 onChangeText={handleChange('password')}
+=======
+                onChangeText={text => setPasswordText(text)}
+>>>>>>> Add authFailed var to Context and listen on it in Login Screen
               />
               { errors.password && touched.password ? errorIcon() : null }
             </View>

--- a/react-native/screens/LoginScreen.js
+++ b/react-native/screens/LoginScreen.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useContext } from 'react';
+import React, { useRef, useContext } from 'react';
 import { View,
          Text,
          TextInput,

--- a/react-native/screens/LoginScreen.js
+++ b/react-native/screens/LoginScreen.js
@@ -19,11 +19,10 @@ import { windowHeight, windowWidth } from '../config/dimensions';
 
 const LoginScreen = props => {
   const { navigation, route } = props;
-  const { login, authFailed, resetAuthStatus } = useContext(AuthContext);
+  const { login } = useContext(AuthContext);
 
   const passwordInputRef = useRef(null);
 
-<<<<<<< HEAD
   const attemptLogin = values => {
     showModal('LOADING');
     setTimeout(() => {
@@ -32,43 +31,6 @@ const LoginScreen = props => {
 
     const loginData = { username: values.username, password: values.password };
     login(loginData);
-=======
-  useEffect(() => {
-    console.log('Auth Failed? ' + authFailed);
-  }, [authFailed]);
-
-  const attemptLogin = () => {
-    if (!emailText || !passwordText) {
-      showModal('VALIDATION_ERROR');
-      setTimeout(() => {
-        hideModal();
-      }, 900);
-    } else {
-      const loginData = { username: emailText, password: passwordText };
-      login(loginData);
-
-      showModal('LOADING');
-      setTimeout(() => {
-        hideModal();
-        checkAuthFailed();
-      }, 1000);
-    }
-  };
-
-  const checkAuthFailed = () => {
-    // console.log('Auth Failed? ' + authFailed);
-    if (authFailed) {
-      showErrorModal();
-    }
-  }
-
-  const showErrorModal = () => {
-    showModal('LOGIN_FAILED');
-    setTimeout(() => {
-      hideModal();
-      resetAuthStatus();
-    }, 900);
->>>>>>> Add authFailed var to Context and listen on it in Login Screen
   };
 
   const errorIcon = () => (
@@ -134,13 +96,9 @@ const LoginScreen = props => {
                 placeholderTextColor={Colors.placeholder_text}
                 returnKeyType='done'
                 secureTextEntry
-<<<<<<< HEAD
                 value={values.password}
                 onBlur={handleBlur('password')}
                 onChangeText={handleChange('password')}
-=======
-                onChangeText={text => setPasswordText(text)}
->>>>>>> Add authFailed var to Context and listen on it in Login Screen
               />
               { errors.password && touched.password ? errorIcon() : null }
             </View>


### PR DESCRIPTION
EDIT: This now is working. It's a somewhat jenky solution, but.... it works! You can try changing the inner `setTimeout` value on line 163 of AuthProvider.js to something really long like 9000 and verify we are able to control time now.

I spent many hours trying to fuss with state management. Could never get better than the 'ever-other' result that Erik was able to achieve. (Using a context within another screen is difficult if it gets more complicated than referencing a single value/function!!!)

Now, we have the two-layered `setTimeout`. The outer one (with 800 as the ms timeout value) basically let's the event queue clear so the LoginScreen or RegisterScreen won't re-render over the modal. Thus, the `showModal` and subsequent inner `setTimeout` which calls `hideModal` is guaranteed to be the last thing to execute, uninterrupted on either Login or Register screen.

Feel free to test and if you find `setTimeout` values that feel better, push a commit! These felt pretty good to me, but I was mostly fed up with this issue once is worked at all.