### PR TITLE
Improve post creation fields

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -24,6 +24,7 @@
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-37.0.1.tar.gz",
+    "react-native-dropdown-picker": "^3.1.11",
     "react-native-gesture-handler": "~1.6.0",
     "react-native-image-editor": "0.0.1",
     "react-native-keyboard-avoiding-scroll-view": "^1.0.1",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -31,6 +31,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.1",
     "react-native-keyboardshift-razzium": "^1.0.0",
     "react-native-paper": "^3.10.1",
+    "react-native-picker-select": "^7.0.0",
     "react-native-reanimated": "~1.7.0",
     "react-native-responsive-fontsize": "^0.4.3",
     "react-native-safe-area-context": "0.7.3",

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -187,7 +187,6 @@ const PostingCreationScreen = props => {
           />
 
         </View>
-
         <View style={styles.inputContainer}>
           <View style={styles.inputView}>
             <TextInput
@@ -202,45 +201,6 @@ const PostingCreationScreen = props => {
               onSubmitEditing={() => descriptionInputRef.current.focus()}
             />
           </View>
-          <RNPickerSelect
-                placeholder={{
-                  label: 'Select an item type...',
-                  value: null,
-                }}
-                items={[
-                  {label: 'Request', value: 'r'},
-                  {label: 'Offer', value: 'o'},
-                ]} 
-                onValueChange={
-                  value =>
-                  {if (value == null) {
-                    setIsRequestSelected(previousState => previousState);
-                  }
-                  else { 
-                    changeType(value);
-                  }
-                }}
-              />
-            <RNPickerSelect
-                //style={styles.dropDown}
-                placeholder={{
-                  label: 'Select a category...',
-                  value: null,
-                }}
-                items={[
-                  {label: 'Good', value: 'g'},
-                  {label: 'Service', value: 's'},
-                ]}
-                onValueChange={
-                  value =>
-                  {if (value == null) {
-                    setIsGoodSelected(previousState => previousState);
-                  }
-                  else {
-                    changeCategory(value);
-                  }
-                }}
-              />
           <View style={{...styles.inputView, ...styles.descriptionInput}}>
             <TextInput
               style={styles.inputText}
@@ -257,20 +217,63 @@ const PostingCreationScreen = props => {
               ref={descriptionInputRef}
             />
           </View>
-          <View style={ (windowHeight > 650) ? styles.switchRowBig : styles.switchRow}>
-            <View style={styles.switchColumn}>
-              <View style={styles.countInputView}>
-                <TextInput
-                  style={styles.countInputText}
-                  placeholder='Quantity...'
-                  placeholderTextColor={Colors.placeholder_text}
-                  keyboardType='numeric'
-                  returnKeyType='done'
-                  onChangeText={text => setItemCount(text)}
-                  ref={itemCountInputRef}
-                />
-              </View>
+          <View style={styles.pickerRow}>
+            <View style={styles.pickerView}>
+              <RNPickerSelect
+                    placeholder={{
+                      label: 'Item type...',
+                      value: null,
+                      color: Colors.placeholder_text,
+                    }}
+                    placeholderTextColor={Colors.placeholder_text}
+                    items={[
+                      {label: 'Request', value: 'r'},
+                      {label: 'Offer', value: 'o'},
+                    ]} 
+                    onValueChange={
+                      value =>
+                      {if (value == null) {
+                        setIsRequestSelected(previousState => previousState);
+                      }
+                      else { 
+                        changeType(value);
+                      }
+                    }}
+                  />
             </View>
+            <View style = {styles.pickerView}>
+              <RNPickerSelect
+                    placeholder={{
+                      label: 'Category...',
+                      value: null,
+                      color: Colors.placeholder_text,
+                    }}
+                    items={[
+                      {label: 'Good', value: 'g'},
+                      {label: 'Service', value: 's'},
+                    ]}
+                    onValueChange={
+                      value =>
+                      {if (value == null) {
+                        setIsGoodSelected(previousState => previousState);
+                      }
+                      else {
+                        changeCategory(value);
+                      }
+                    }}
+              />
+            </View>
+          </View>
+          <View style={styles.countInputView}>
+            <TextInput
+              style={styles.countInputText}
+              placeholder='Quantity...'
+              placeholderTextColor={Colors.placeholder_text}
+              keyboardType='numeric'
+              returnKeyType='done'
+              onChangeText={text => setItemCount(text)}
+              ref={itemCountInputRef}
+            />
           </View>
         </View>
         <CustomButton
@@ -359,6 +362,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
+    width: 110,
 
     backgroundColor: Colors.light_shade4,
     borderRadius: 10,
@@ -382,31 +386,13 @@ const styles = StyleSheet.create({
     color: Colors.dark_shade1,
     textAlign: 'center',
   },
-  switchRowBig: {
+  pickerRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginVertical: 10,
-    marginBottom: 60,
   },
-  switchRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginHorizontal: 20,
-    marginVertical: -(windowHeight/70)
-  },
-  switchColumn: {
-    alignItems: 'center',
-  },
-  switchTitle: {
-    fontSize: 16,
-    marginBottom: 10,
-  },
-  switch: {
-      transform: [{ scaleX: 1.5 }, { scaleY: 1.5 }],
-  },
-  dropDown: {
-    width:100, 
-    height: 40,
+  pickerView: {
+    flex: 0.5,
+    marginBottom: windowHeight/40,
   },
   confirmButton: {
     marginBottom: 0,

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -43,8 +43,8 @@ const PostingCreationScreen = props => {
   const [itemName, setItemName] = useState('');
   const [itemDescription, setItemDescription] = useState('');
   const [itemCount, setItemCount] = useState(1);
-  const [isRequestSelected, setIsRequestSelected] = useState(false);
-  const [isCategorySwitchEnabled, setIsCategorySwitchEnabled] = useState(false);
+  const [isRequestSelected, setIsRequestSelected] = useState(true);
+  const [isGoodSelected, setIsGoodSelected] = useState(true);
   const [isProcessing, setIsProcessing] = useState(false);
 
   const nameInputRef = useRef(null);
@@ -69,7 +69,7 @@ const PostingCreationScreen = props => {
 
   // Create the data object in correct format to be sent off the server
   const createFormData = () => {
-    const categoryValue = isCategorySwitchEnabled ? 'services' : 'goods';
+    const categoryValue = isGoodSelected ? 'goods' : 'services';
     const requestValue = isRequestSelected ? true : false;
 
     const data = new FormData();
@@ -124,8 +124,8 @@ const PostingCreationScreen = props => {
     setItemCount(1);
     setIsProcessing(false);
 
-    setIsRequestSelected(false);
-    setIsCategorySwitchEnabled(false);
+    setIsRequestSelected(true);
+    setIsGoodSelected(true);
 
     nameInputRef.current.clear();
     descriptionInputRef.current.clear();
@@ -149,9 +149,16 @@ const PostingCreationScreen = props => {
     }
   };
 
-  const toggleCategorySwitch = () => {
-    setIsCategorySwitchEnabled(previousState => !previousState);
-  };
+  const changeCategory = (item) => {
+    switch (item.value) {
+      case 'g':
+        setIsGoodSelected(true);
+      break;
+      case 's':
+        setIsGoodSelected(false);
+      break;
+    }
+  }
 
   const selectImage = imageData => {
     // console.log("In selectImage: " + JSON.stringify(imageData));
@@ -238,13 +245,15 @@ const PostingCreationScreen = props => {
               />
             </View>
             <View style={styles.switchColumn}>
-              <Text style={styles.switchTitle}>Category</Text>
-              <Switch
-                style={styles.switch}
-                onValueChange={toggleCategorySwitch}
-                value={isCategorySwitchEnabled}
-                trackColor={{ false: "#767577", true: Colors.primary }}
-                thumbColor={isCategorySwitchEnabled ? Colors.primary : "#f4f3f4"}
+              <DropDownPicker
+                style={styles.dropDown}
+                items={[
+                  {label: 'Good', value: 'g'},
+                  {label: 'Service', value: 's'},
+                ]}
+                defaultValue='g'
+                containerStyle={styles.dropDown}
+                onChangeItem={item => changeCategory(item)}
               />
             </View>
           </View>

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -18,6 +18,7 @@ import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
 import { WToast } from 'react-native-smart-tip'
 import { KeyboardAvoidingScrollView } from 'react-native-keyboard-avoiding-scroll-view';
+import DropDownPicker from 'react-native-dropdown-picker';
 
 import { showModal, hideModal } from '../components/CustomModal';
 import { notifyMessage } from '../components/CustomToast';
@@ -42,7 +43,7 @@ const PostingCreationScreen = props => {
   const [itemName, setItemName] = useState('');
   const [itemDescription, setItemDescription] = useState('');
   const [itemCount, setItemCount] = useState(1);
-  const [isRequestSwitchEnabled, setIsRequestSwitchEnabled] = useState(false);
+  const [isRequestSelected, setIsRequestSelected] = useState(false);
   const [isCategorySwitchEnabled, setIsCategorySwitchEnabled] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
 
@@ -69,7 +70,7 @@ const PostingCreationScreen = props => {
   // Create the data object in correct format to be sent off the server
   const createFormData = () => {
     const categoryValue = isCategorySwitchEnabled ? 'services' : 'goods';
-    const requestValue = isRequestSwitchEnabled ? true : false;
+    const requestValue = isRequestSelected ? true : false;
 
     const data = new FormData();
 
@@ -123,7 +124,7 @@ const PostingCreationScreen = props => {
     setItemCount(1);
     setIsProcessing(false);
 
-    setIsRequestSwitchEnabled(false);
+    setIsRequestSelected(false);
     setIsCategorySwitchEnabled(false);
 
     nameInputRef.current.clear();
@@ -137,8 +138,15 @@ const PostingCreationScreen = props => {
     navigation.navigate('Home', {screen: 'Feed'})
   }
 
-  const toggleRequestSwitch = () => {
-    setIsRequestSwitchEnabled(previousState => !previousState);
+  const changeType = (item) => {
+    switch (item.value) {
+      case 'r':
+        setIsRequestSelected(true);
+      break;
+      case 'o':
+        setIsRequestSelected(false);
+      break;
+    }
   };
 
   const toggleCategorySwitch = () => {
@@ -205,27 +213,29 @@ const PostingCreationScreen = props => {
           </View>
           <View style={ (windowHeight > 650) ? styles.switchRowBig : styles.switchRow}>
             <View style={styles.switchColumn}>
-              <Text style={styles.switchTitle}>Request?</Text>
-              <Switch
-                style={styles.switch}
-                onValueChange={toggleRequestSwitch}
-                value={isRequestSwitchEnabled}
-                trackColor={{ false: "#767577", true: Colors.primary }}
-                thumbColor={isRequestSwitchEnabled ? Colors.primary : "#f4f3f4"}
-              />
-            </View>
-            <View style={styles.switchColumn}>
-              <Text style={styles.switchTitle}>Count</Text>
               <View style={styles.countInputView}>
                 <TextInput
                   style={styles.countInputText}
+                  placeholder='Quantity...'
+                  placeholderTextColor={Colors.placeholder_text}
                   keyboardType='numeric'
                   returnKeyType='done'
-                  value={itemCount.toString()}
                   onChangeText={text => setItemCount(text)}
                   ref={itemCountInputRef}
                 />
               </View>
+            </View>
+            <View style={styles.switchColumn}>
+              <DropDownPicker
+                style={styles.dropDown}
+                items={[
+                  {label: 'Request', value: 'r'},
+                  {label: 'Offer', value: 'o'},
+                ]}
+                defaultValue='r'
+                containerStyle={styles.dropDown}
+                onChangeItem={item => changeType(item)}
+              />
             </View>
             <View style={styles.switchColumn}>
               <Text style={styles.switchTitle}>Category</Text>
@@ -351,8 +361,8 @@ const styles = StyleSheet.create({
   switchRowBig: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginHorizontal: 20,
-    marginVertical: 10
+    marginVertical: 10,
+    marginBottom: 60,
   },
   switchRow: {
     flexDirection: 'row',
@@ -369,6 +379,10 @@ const styles = StyleSheet.create({
   },
   switch: {
       transform: [{ scaleX: 1.5 }, { scaleY: 1.5 }],
+  },
+  dropDown: {
+    width:100, 
+    height: 40,
   },
   confirmButton: {
     marginBottom: 0,

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -220,22 +220,17 @@ const PostingCreationScreen = props => {
           <View style={styles.pickerRow}>
             <View style={styles.pickerView}>
               <RNPickerSelect
-                    placeholder={{
-                      label: 'Item type...',
-                      value: null,
-                      color: Colors.placeholder_text,
-                    }}
-                    placeholderTextColor={Colors.placeholder_text}
+                    placeholder={{}}
                     items={[
                       {label: 'Request', value: 'r'},
                       {label: 'Offer', value: 'o'},
-                    ]} 
+                    ]}
                     onValueChange={
                       value =>
                       {if (value == null) {
                         setIsRequestSelected(previousState => previousState);
                       }
-                      else { 
+                      else {
                         changeType(value);
                       }
                     }}
@@ -243,14 +238,10 @@ const PostingCreationScreen = props => {
             </View>
             <View style = {styles.pickerView}>
               <RNPickerSelect
-                    placeholder={{
-                      label: 'Category...',
-                      value: null,
-                      color: Colors.placeholder_text,
-                    }}
+                    placeholder={{}}
                     items={[
-                      {label: 'Good', value: 'g'},
-                      {label: 'Service', value: 's'},
+                      {label: 'Goods', value: 'g'},
+                      {label: 'Services', value: 's'},
                     ]}
                     onValueChange={
                       value =>
@@ -264,16 +255,25 @@ const PostingCreationScreen = props => {
               />
             </View>
           </View>
-          <View style={styles.countInputView}>
-            <TextInput
-              style={styles.countInputText}
-              placeholder='Quantity...'
-              placeholderTextColor={Colors.placeholder_text}
-              keyboardType='numeric'
-              returnKeyType='done'
-              onChangeText={text => setItemCount(text)}
-              ref={itemCountInputRef}
-            />
+          <View style={styles.countView}>
+            <View style={styles.countInputTitle}>
+                <Text style={styles.countInputTitleText}>
+                  Quantity:
+                </Text>
+              </View>
+            <View>
+              <View style={styles.countInputView}>
+                <TextInput
+                  style={styles.countInputText}
+                  placeholderTextColor={Colors.placeholder_text}
+                  keyboardType='numeric'
+                  returnKeyType='done'
+                  value = '1'
+                  onChangeText={text => setItemCount(text)}
+                  ref={itemCountInputRef}
+                />
+              </View>
+            </View>
           </View>
         </View>
         <CustomButton
@@ -358,11 +358,23 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     color: Colors.dark_shade1,
   },
+  countView: {
+    alignItems: 'center',
+    marginHorizontal: windowWidth/18,
+  },
+  countInputTitle: {
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  countInputTitleText: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
   countInputView: {
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    width: 110,
+    width: windowWidth/4,
 
     backgroundColor: Colors.light_shade4,
     borderRadius: 10,
@@ -389,10 +401,19 @@ const styles = StyleSheet.create({
   pickerRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    marginHorizontal: windowWidth/18,
   },
   pickerView: {
     flex: 0.5,
-    marginBottom: windowHeight/40,
+    alignItems: 'center',
+    marginBottom: windowHeight/75,
+  },
+  pickerTitle: {
+    flex: 0.5,
+  },
+  pickerTitleText: {
+    fontWeight: 'bold',
+    fontSize: 16,
   },
   confirmButton: {
     marginBottom: 0,

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -9,9 +9,10 @@ import { StyleSheet,
          ScrollView,
          Dimensions,
          Image,
+         Platform,
          ActivityIndicator,
        } from "react-native";
-import { FontAwesome5 } from '@expo/vector-icons';
+import { FontAwesome } from '@expo/vector-icons';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { useHeaderHeight } from '@react-navigation/stack';
 import * as ImagePicker from 'expo-image-picker';
@@ -52,6 +53,7 @@ const PostingCreationScreen = props => {
   const itemCountInputRef = useRef(null);
 
   const height = useHeaderHeight();
+  const isAndroid = Platform.OS === 'android';
 
   const handlePostCreation = () => {
     if(!isProcessing) {
@@ -218,7 +220,8 @@ const PostingCreationScreen = props => {
             />
           </View>
           <View style={styles.pickerRow}>
-            <View style={styles.pickerView}>
+
+            <View style={isAndroid ? styles.pickerViewAndroid : {...styles.inputView, ...styles.pickerViewiOS}}>
               <RNPickerSelect
                     placeholder={{}}
                     items={[
@@ -236,8 +239,9 @@ const PostingCreationScreen = props => {
                     }}
                   />
             </View>
-            <View style = {styles.pickerView}>
+            <View style={isAndroid ? styles.pickerViewAndroid : {...styles.inputView, ...styles.pickerViewiOS}}>
               <RNPickerSelect
+                style={styles.picker}
                     placeholder={{}}
                     items={[
                       {label: 'Goods', value: 'g'},
@@ -303,12 +307,12 @@ const styles = StyleSheet.create({
   imageContainerBig: {
     width: '100%',
     alignItems: 'center',
-    marginBottom: windowHeight / 20
+    marginBottom: windowHeight / 20,
   },
   imageContainer: {
     width: '100%',
     alignItems: 'center',
-    marginVertical: windowHeight / 40
+    marginVertical: windowHeight / 40,
   },
   textInput: {
     width: '100%',
@@ -349,7 +353,6 @@ const styles = StyleSheet.create({
   },
   descriptionInput: {
     height: 80,
-    alignItems: 'flex-start',
   },
   inputText: {
     width: '90%',
@@ -398,13 +401,16 @@ const styles = StyleSheet.create({
   },
   pickerRow: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginHorizontal: windowWidth / 18,
+    justifyContent: 'space-around',
   },
-  pickerView: {
-    flex: 0.5,
-    alignItems: 'center',
-    marginBottom: windowHeight/75,
+  pickerViewiOS: {
+    width: '45%',
+    paddingTop: 15,
+    marginBottom: windowHeight / 75,
+  },
+  pickerViewAndroid: {
+    width: '45%',
+    marginBottom: windowHeight / 75,
   },
   pickerTitle: {
     flex: 0.5,

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -258,21 +258,19 @@ const PostingCreationScreen = props => {
           <View style={styles.countView}>
             <View style={styles.countInputTitle}>
                 <Text style={styles.countInputTitleText}>
-                  Quantity:
+                  Quantity
                 </Text>
               </View>
-            <View>
-              <View style={styles.countInputView}>
-                <TextInput
-                  style={styles.countInputText}
-                  placeholderTextColor={Colors.placeholder_text}
-                  keyboardType='numeric'
-                  returnKeyType='done'
-                  value = '1'
-                  onChangeText={text => setItemCount(text)}
-                  ref={itemCountInputRef}
-                />
-              </View>
+            <View style={styles.countInputView}>
+              <TextInput
+                style={styles.countInputText}
+                placeholderTextColor={Colors.placeholder_text}
+                keyboardType='numeric'
+                returnKeyType='done'
+                value={itemCount.toString()}
+                onChangeText={text => setItemCount(text)}
+                ref={itemCountInputRef}
+              />
             </View>
           </View>
         </View>
@@ -374,13 +372,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    width: windowWidth/4,
+    width: 60,
+    height: 40,
 
     backgroundColor: Colors.light_shade4,
     borderRadius: 10,
     borderColor: Colors.placeholder_text,
     borderWidth: 0.5,
-    height: 30,
     marginBottom: windowHeight/40,
     paddingHorizontal: 20,
 
@@ -401,7 +399,7 @@ const styles = StyleSheet.create({
   pickerRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginHorizontal: windowWidth/18,
+    marginHorizontal: windowWidth / 18,
   },
   pickerView: {
     flex: 0.5,

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -18,7 +18,7 @@ import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
 import { WToast } from 'react-native-smart-tip'
 import { KeyboardAvoidingScrollView } from 'react-native-keyboard-avoiding-scroll-view';
-import DropDownPicker from 'react-native-dropdown-picker';
+import RNPickerSelect from 'react-native-picker-select';
 
 import { showModal, hideModal } from '../components/CustomModal';
 import { notifyMessage } from '../components/CustomToast';
@@ -138,8 +138,8 @@ const PostingCreationScreen = props => {
     navigation.navigate('Home', {screen: 'Feed'})
   }
 
-  const changeType = (item) => {
-    switch (item.value) {
+  const changeType = (value) => {
+    switch (value) {
       case 'r':
         setIsRequestSelected(true);
       break;
@@ -149,8 +149,8 @@ const PostingCreationScreen = props => {
     }
   };
 
-  const changeCategory = (item) => {
-    switch (item.value) {
+  const changeCategory = (value) => {
+    switch (value) {
       case 'g':
         setIsGoodSelected(true);
       break;
@@ -202,6 +202,45 @@ const PostingCreationScreen = props => {
               onSubmitEditing={() => descriptionInputRef.current.focus()}
             />
           </View>
+          <RNPickerSelect
+                placeholder={{
+                  label: 'Select an item type...',
+                  value: null,
+                }}
+                items={[
+                  {label: 'Request', value: 'r'},
+                  {label: 'Offer', value: 'o'},
+                ]} 
+                onValueChange={
+                  value =>
+                  {if (value == null) {
+                    setIsRequestSelected(previousState => previousState);
+                  }
+                  else { 
+                    changeType(value);
+                  }
+                }}
+              />
+            <RNPickerSelect
+                //style={styles.dropDown}
+                placeholder={{
+                  label: 'Select a category...',
+                  value: null,
+                }}
+                items={[
+                  {label: 'Good', value: 'g'},
+                  {label: 'Service', value: 's'},
+                ]}
+                onValueChange={
+                  value =>
+                  {if (value == null) {
+                    setIsGoodSelected(previousState => previousState);
+                  }
+                  else {
+                    changeCategory(value);
+                  }
+                }}
+              />
           <View style={{...styles.inputView, ...styles.descriptionInput}}>
             <TextInput
               style={styles.inputText}
@@ -231,30 +270,6 @@ const PostingCreationScreen = props => {
                   ref={itemCountInputRef}
                 />
               </View>
-            </View>
-            <View style={styles.switchColumn}>
-              <DropDownPicker
-                style={styles.dropDown}
-                items={[
-                  {label: 'Request', value: 'r'},
-                  {label: 'Offer', value: 'o'},
-                ]}
-                defaultValue='r'
-                containerStyle={styles.dropDown}
-                onChangeItem={item => changeType(item)}
-              />
-            </View>
-            <View style={styles.switchColumn}>
-              <DropDownPicker
-                style={styles.dropDown}
-                items={[
-                  {label: 'Good', value: 'g'},
-                  {label: 'Service', value: 's'},
-                ]}
-                defaultValue='g'
-                containerStyle={styles.dropDown}
-                onChangeItem={item => changeCategory(item)}
-              />
             </View>
           </View>
         </View>


### PR DESCRIPTION
I changed the toggle switches on the "Create a posting" screen to picker select components, so that the user can select whether their post is a request or offer, or is a good or service. I also played with the layout of the fields on the page, so that they were a bit more spread out. I think there is still work to be done in formatting (particularly with the way the picker select components are laid out on the screen), but it should work functionally. 

- Tested only on Android so please try on iOS if you can