### PR TITLE
Fix email ssl

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -8,6 +8,7 @@ RUN echo `python3 --version`
 
 # Set environment variables
 ENV PYTHONUNBUFFERED 1
+ENV SENDGRID_API_KEY="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"
 
 COPY requirements.txt /
 

--- a/django/cgproj/settings.py
+++ b/django/cgproj/settings.py
@@ -144,13 +144,16 @@ MEDIA_ROOT = "media/"
 
 UPLOAD_ROOT = 'media/uploads/'
 
+SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.sendgrid.net'
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-EMAIL_HOST_USER = os.getenv('EMAIL_USER')
-EMAIL_HOST_PASSWORD = os.getenv('EMAIL_PASSWORD')
+#EMAIL_PORT = 587  # TLS port
+EMAIL_PORT = 465  # SSL port
+EMAIL_USE_TLS = False
+EMAIL_USE_SSL = True
+EMAIL_HOST_USER = 'apikey'
+EMAIL_HOST_PASSWORD = SENDGRID_API_KEY
 DEFAULT_FROM_EMAIL = 'commongoodsmail@gmail.com'
 
 


### PR DESCRIPTION
Resolves #249 -- When switching to ace-mote, the reach out feature for emails experienced failures in 2 places:
1. The EMAIL_HOST_USER and EMAIL_HOST_PASSWORD were not set, resulting in an unauthenticated sender error appearing
2. The emails being sent were over TLS, not SSL

I explicitly set the host user to 'apikey' and the password to the environment variable for SENDGRID_API_KEY; this makes it more obvious that we are simply using an API key to authenticate to our SMTP server.

I also added EMAIL_USE_SSL in tandem with EMAIL_USE_TLS, as well as changing the port. This allows us to switch between TLS and SSL easier without consulting external documentation.