### PR TITLE
app.json configuration for builds and make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: server js console deploy install install2
+.PHONY: server js console deploy install install2 build-droid build-ios
 
 # Default target: Run expo server
 js:
@@ -23,3 +23,11 @@ install:
 # Install app-specific packages
 install2:
 	sudo bash qa/prereq-linux2.sh
+
+# Build android apk
+build-droid:
+	cd react-native && expo build:android -t apk
+
+# Build iOS tarball (for emulators)
+build-ios:
+	cd react-native && expo build:ios

--- a/react-native/app.json
+++ b/react-native/app.json
@@ -1,11 +1,10 @@
 {
   "expo": {
-    "name": "react-native",
-    "slug": "react-native",
+    "name": "CommonGoods",
+    "slug": "common-goods",
     "platforms": [
       "ios",
-      "android",
-      "web"
+      "android"
     ],
     "version": "1.0.0",
     "orientation": "portrait",
@@ -22,7 +21,13 @@
       "**/*"
     ],
     "ios": {
+      "bundleIdentifier": "com.pdxcapstone.CommonGoods",
+      "buildNumber": "1.0.0",
       "supportsTablet": true
+    },
+    "android": {
+      "package": "com.pdxcapstone.CommonGoods",
+      "versionCode": 1
     }
   }
 }

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -157,7 +157,7 @@ console.log(latlng);
       },
       body: requestJSON,
     })
-      .then(response => response.text())
+      .then(response => {console.log(response.status); return response.text() })
       .then(text => {
         console.log('Response from sendEmail: ' + text);
       })

--- a/react-native/web-build/register-service-worker.js
+++ b/react-native/web-build/register-service-worker.js
@@ -1,13 +1,13 @@
 /* eslint-env browser */
 
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', function () {
+  window.addEventListener('load', function() {
     navigator.serviceWorker
       .register('/expo-service-worker.js', { scope: '/' })
-      .then(function (info) {
+      .then(function(info) {
         // console.info('Registered service-worker', info);
       })
-      .catch(function (error) {
+      .catch(function(error) {
         console.info('Failed to register service-worker', error);
       });
   });


### PR DESCRIPTION
Setup config and verified builds are achievable. Two download example links in #254.

A few notes:
1. Requires being signed into Expo account to run builds (you can set one up for free if doesn't exist already).
2. When either `make build-droid` or `make build-ios` is run, it simply runs Expo CLI, figured it'd be easier to remember make commands.
3. If you do run a build, when expo prompts you about a keystore choose the "Let us handle it for you option".
4. As the build process warns, when we have our images finalized, we should run `npx expo-optimize` in the project folder to optimize our images and make them load fast.

We could change any of the config settings as we wish. Will probably want to update our version number on our final packages.

Closes #254.