### PR TITLE
Add auth & permission classes to API endpoints

### DIFF
--- a/django/cgapi/views.py
+++ b/django/cgapi/views.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import action, api_view, authentication_classes, permission_classes, renderer_classes
 from rest_framework.renderers import JSONRenderer
 from rest_framework.authentication import TokenAuthentication
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import IsAuthenticated, AllowAny, IsAdminUser, ReadOnly
 from rest_framework.views import APIView
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
@@ -65,7 +65,7 @@ class CommunityViewSet(ModelViewSet):
     """API endpoint for communities"""
     queryset = Community.objects.all()
     authentication_classes = [TokenAuthentication]
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAdminUser|ReadOnly]
     serializer_class = CommunitySerializer
     
     @action(detail=True)

--- a/django/cgapi/views.py
+++ b/django/cgapi/views.py
@@ -18,6 +18,8 @@ import datetime
         
 class PostingViewSet(ModelViewSet):
     queryset = Posting.objects.all()
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
     serializer_class = PostingSerializer
     
     @action(detail=False)
@@ -29,12 +31,10 @@ class PostingViewSet(ModelViewSet):
     
     @action(detail=False)
     @api_view(['GET'])
-    @authentication_classes([TokenAuthentication])
-    @permission_classes([IsAuthenticated])
     def auth(request):
-            posting = Posting.objects.all()
-            serializer = PostingSerializer(posting, many=True)
-            return Response(serializer.data)
+        posting = Posting.objects.all()
+        serializer = PostingSerializer(posting, many=True)
+        return Response(serializer.data)
             
     @action(detail=False, methods=['POST'])
     def contact(self, request):
@@ -62,6 +62,8 @@ class CommunityViewSet(ModelViewSet):
     API endpoint allowing Community objects to be created, viewed, edited, deleted
     """
     queryset = Community.objects.all()
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
     serializer_class = CommunitySerializer
     
     @action(detail=True)
@@ -72,10 +74,14 @@ class CommunityViewSet(ModelViewSet):
 
 class UserProfileViewSet(ModelViewSet):
     queryset = UserProfile.objects.all()
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
     serializer_class = UserProfileSerializer
         
 class UserViewSet(ModelViewSet):
     queryset = User.objects.all()
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
     serializer_class = UserSerializer
     
     @action(detail=True)

--- a/django/cgapi/views.py
+++ b/django/cgapi/views.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import json
 from rest_framework.viewsets import ModelViewSet
@@ -14,9 +15,10 @@ from django.contrib.auth.models import User
 from django.core.mail import EmailMessage
 from .models import Posting, Community, UserProfile
 from .serializers import PostingSerializer, CommunitySerializer, UserProfileSerializer, UserSerializer
-import datetime
         
+
 class PostingViewSet(ModelViewSet):
+    """API Endpoint for postings"""
     queryset = Posting.objects.all()
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
@@ -38,6 +40,7 @@ class PostingViewSet(ModelViewSet):
             
     @action(detail=False, methods=['POST'])
     def contact(self, request):
+        """Send an email to contact the owner of the posting"""
         if request.method == 'POST':
             post_id = request.data.get('postid', '')
             related_post = Posting.objects.get(pk=post_id)
@@ -57,10 +60,9 @@ class PostingViewSet(ModelViewSet):
             email.send()
         return Response(request.data)
 
+
 class CommunityViewSet(ModelViewSet):
-    """
-    API endpoint allowing Community objects to be created, viewed, edited, deleted
-    """
+    """API endpoint for communities"""
     queryset = Community.objects.all()
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
@@ -68,17 +70,22 @@ class CommunityViewSet(ModelViewSet):
     
     @action(detail=True)
     def postings(self, request, *args, **kwargs):
+        """Show all postings for a given community"""
         community = self.get_object()
         posting_serializer = PostingSerializer(community.posts, many=True)
         return Response(posting_serializer.data)
 
+
 class UserProfileViewSet(ModelViewSet):
+    """API endpoint for user profiles"""
     queryset = UserProfile.objects.all()
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = UserProfileSerializer
         
+
 class UserViewSet(ModelViewSet):
+    """API endpoint for users"""
     queryset = User.objects.all()
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
@@ -94,6 +101,7 @@ class UserViewSet(ModelViewSet):
 @api_view(('POST',))
 @renderer_classes((JSONRenderer,))
 def register_user(request):
+    """Register a new user"""
     post_data = json.loads(request.body)
     usrpw = post_data.get('password')
     serializer = UserSerializer(data=post_data)
@@ -112,8 +120,10 @@ def register_user(request):
         return Response(content)
     return Response(data=serializer.errors)   
     
+
 @api_view(('GET',))
 def username_available(request):
+    """Endpoint to check if a username is available"""
     argument = request.query_params.get('username', '')
     if User.objects.filter(username=argument).exists():
         return Response(status=409)
@@ -121,6 +131,8 @@ def username_available(request):
     
     
 class CustomAuthToken(ObtainAuthToken):
+    """Obtain an authentication token"""
+
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
Add two classes to existing endpoints (except for user registration and login):
- `permission_classes = [IsAuthenticated]` to require authentication when accessing API endpoints
- `authentication_classes = [TokenAuthentication]` as the method of authentication

Note: The removal of the authentication_class and permission_class on the `auth` method in PostingViewSet becomes redundant when we set the auth & permission class on the class itself, so I removed for the sake of cleaner code :)

Resolves #235, #263 