### PR TITLE
Filter by communities

### DIFF
--- a/django/cgapi/filters.py
+++ b/django/cgapi/filters.py
@@ -9,7 +9,7 @@ class PostingFilter(filters.FilterSet):
 
     class Meta:
         model = Posting
-        fields = ['radius',]
+        fields = ['radius', 'communities',]
 
     def radius_filter(self, queryset, name, value):
         """Filter postings in a radius about a given longitude/latitude"""
@@ -20,5 +20,13 @@ class PostingFilter(filters.FilterSet):
             radius = int(rad)
             point = Point(float(lng), float(lat))
             return queryset.filter(location__distance_lt=(point, Distance(mi=radius)))
+        return queryset.none()
+
+    def communities_filter(self, queryset, name, value):
+        """Filter postings by a list of community IDs"""
+        communities = self.request.GET.get('communities')
+        if communities is not None:
+            ids = communities.split(',')
+            return queryset.filter(in_community__in=ids)
         return queryset.none()
 

--- a/django/cgapi/filters.py
+++ b/django/cgapi/filters.py
@@ -26,7 +26,8 @@ class PostingFilter(filters.FilterSet):
         """Filter postings by a list of community IDs"""
         communities = self.request.GET.get('communities')
         if communities is not None:
-            ids = communities.split(',')
+            # Cast all strings to integers in list
+            ids = [int(i) for i in communities.split(',')]
             return queryset.filter(in_community__in=ids)
         return queryset.none()
 


### PR DESCRIPTION
**IMPORTANT** : This is branched from the add-radius-filter branch and should be merged in afterwards

This adds a filter at /postings/ that allows users to filter postings by a list of community IDs. For example:
- `/postings/?communities=1,2,3,4,5`
Would filter communities by several IDs.

Resolves #244