### PR TITLE
Erik add postings to context

### DIFF
--- a/react-native/components/CustomModal.js
+++ b/react-native/components/CustomModal.js
@@ -82,6 +82,11 @@ const updateProfileOptions = {
     data: 'Updating Profile...',
 };
 
+const updateLocationOptions = {
+    ...defaultOptions,
+    data: 'Updating Location...',
+};
+
 export function showModal(type) {
     let options;
 
@@ -124,6 +129,9 @@ export function showModal(type) {
             break;
         case 'UPDATING_PROFILE':
             options = updateProfileOptions;
+            break;
+        case 'UPDATING_LOCATION':
+            options = updateLocationOptions;
             break;
         default:
             options = defaultOptions;

--- a/react-native/components/CustomModal.js
+++ b/react-native/components/CustomModal.js
@@ -27,6 +27,11 @@ const updatePostingOptions = {
     data: 'Updating your Posting...',
 };
 
+const flaggingPostingOptions = {
+    ...defaultOptions,
+    data: 'Flagging Posting...',
+};
+
 const loginFailedOptions = {
     ...defaultOptions,
     data: 'Login Failed!',
@@ -95,6 +100,9 @@ export function showModal(type) {
             break;
         case 'UPDATING_POSTING':
             options = updatePostingOptions;
+            break;
+        case 'FLAGGING_POSTING':
+            options = flaggingPostingOptions;
             break;
         case 'DELETE_POSTING':
             options = deletePostingOptions;

--- a/react-native/components/DrawerContent.js
+++ b/react-native/components/DrawerContent.js
@@ -15,8 +15,6 @@ import {
   Paragraph,
   Drawer,
   Text,
-  TouchableRipple,
-  Switch
 } from 'react-native-paper';
 
 import { AuthContext } from '../providers/AuthProvider';
@@ -157,7 +155,6 @@ const DrawerContent = props => {
               onPress={() => {navigation.navigate('Settings')}}
             />
           </Drawer.Section>
-
         </View>
       </DrawerContentScrollView>
       <Drawer.Section style={styles.bottomDrawerSection}>

--- a/react-native/components/DrawerContent.js
+++ b/react-native/components/DrawerContent.js
@@ -154,7 +154,7 @@ const DrawerContent = props => {
                 />
               )}
               label="Settings"
-              onPress={() => {}}
+              onPress={() => {navigation.navigate('Settings')}}
             />
           </Drawer.Section>
 

--- a/react-native/components/Map.js
+++ b/react-native/components/Map.js
@@ -1,10 +1,20 @@
-import React from 'react';
+import React, { useEffect, useContext, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import MapView, { Marker, Circle, PROVIDER_GOOGLE } from 'react-native-maps';
+
+import { AuthContext } from '../providers/AuthProvider';
 import Colors from '../config/colors';
 
 const Map = props => {
   const { radius, location } = props;
+  const { user } = useContext(AuthContext);
+  const [region, setRegion] = useState({
+    latitude: location.latitude,
+    longitude: location.longitude,
+    latitudeDelta: 0.0922,
+    longitudeDelta: 0.0421,
+  });
+
 
   if (location) {
     var point = location;
@@ -17,6 +27,10 @@ const Map = props => {
   else {
     console.log("null point");
   }
+
+  useEffect(() => {
+    generateRandomCircleCenter(radius, modifiedPoint);
+  }, [user.profile.home_location]);
 
   // const parseLocation = point => {
 
@@ -50,6 +64,10 @@ const Map = props => {
 
   generateRandomCircleCenter(radius, modifiedPoint);
 
+  const changeRegion = () => {
+
+  };
+
   return(
     <View style={{ ...styles.mapContainer, ...props.style }}>
       <MapView
@@ -63,6 +81,7 @@ const Map = props => {
           latitudeDelta: 0.0922,
           longitudeDelta: 0.0421,
         }}
+        onRegionChange={changeRegion}
       >
         { props.no_circle ? null
           :
@@ -73,9 +92,11 @@ const Map = props => {
             strokeColor={Colors.map_circle_stroke}
           />
         }
-        <Marker
-          coordinate={truePoint}
-        />
+        { props.hide_point ? null
+          : <Marker
+                 coordinate={truePoint}
+          />
+        }
       </MapView>
     </View>
   );

--- a/react-native/components/Map.js
+++ b/react-native/components/Map.js
@@ -64,12 +64,15 @@ const Map = props => {
           longitudeDelta: 0.0421,
         }}
       >
-        <Circle
-          center={modifiedPoint}
-          radius={radius}
-          fillColor={Colors.map_circle_fill}
-          strokeColor={Colors.map_circle_stroke}
-        />
+        { props.no_circle ? null
+          :
+          <Circle
+            center={modifiedPoint}
+            radius={radius}
+            fillColor={Colors.map_circle_fill}
+            strokeColor={Colors.map_circle_stroke}
+          />
+        }
         <Marker
           coordinate={truePoint}
         />

--- a/react-native/components/Map.js
+++ b/react-native/components/Map.js
@@ -16,6 +16,10 @@ const Map = props => {
   });
 
 
+  useEffect(() => {
+    
+  }, [user.profile.home_location]);
+
   if (location) {
     var point = location;
     point = point.slice(point.indexOf('(') + 1, point.indexOf(')'));
@@ -28,9 +32,6 @@ const Map = props => {
     console.log("null point");
   }
 
-  useEffect(() => {
-    generateRandomCircleCenter(radius, modifiedPoint);
-  }, [user.profile.home_location]);
 
   // const parseLocation = point => {
 
@@ -65,7 +66,10 @@ const Map = props => {
   generateRandomCircleCenter(radius, modifiedPoint);
 
   const changeRegion = () => {
-
+    setRegion({
+      ...region,
+      ...modifiedPoint,
+    })
   };
 
   return(

--- a/react-native/components/PostingList.js
+++ b/react-native/components/PostingList.js
@@ -6,7 +6,7 @@ import { AuthContext } from '../providers/AuthProvider';
 
 const PostingList = props => {
   const { navigation, searchText } = props;
-  const { user, postings, postings_updated } = useContext(AuthContext);
+  const { user, postings, postings_updated, searchMethod } = useContext(AuthContext);
   const [filteredPostings, setFilteredPostings] = useState([]);
 
   useEffect(() => {
@@ -14,10 +14,17 @@ const PostingList = props => {
   }, [props.searchText, postings_updated, user.profile.member_of]);
 
   const filterPostings = filterType => {
-    let filtered = postings.filter(posting => {
-      return user.profile.member_of.includes(posting.in_community);
-    });
+    let filtered = postings;
 
+    // filtering by searchMethod
+    if (searchMethod === 'COMMUNITY') {
+      filtered = postings.filter(posting => {
+        return user.profile.member_of.includes(posting.in_community);
+      });
+
+    }
+
+    // filtering by postingListScreen type
     if (props.filterType === 'FLAGGED') {
       filtered = filtered.filter(posting => posting.flagged > 0);
     } else if (props.filterType === 'SAVED') {
@@ -28,6 +35,7 @@ const PostingList = props => {
         posting.owner === user.user.id);
     }
 
+    // search filtering
     if (searchText.length > 0) {
       filtered = filtered.filter(posting =>
         posting.title.toLowerCase().includes(

--- a/react-native/components/PostingList.js
+++ b/react-native/components/PostingList.js
@@ -1,43 +1,45 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { View, StyleSheet, FlatList, RefreshControl } from 'react-native';
 
 import PostingListItem from '../components/PostingListItem';
+import { AuthContext } from '../providers/AuthProvider';
 
 const PostingList = props => {
-    const { postings, navigation } = props;
+  const { navigation } = props;
+  const { postings } = useContext(AuthContext);
 
-    const renderPostingListItem = itemData => {
-        return(
-          <View style={styles.list}>
-            <PostingListItem
-              title={itemData.item.title}
-              request={itemData.item.request}
-              item_pic={itemData.item.item_pic}
-              in_community={itemData.item.in_community}
-              location={itemData.item.location}
-              flagged={itemData.item.flagged}
-              onSelectPosting={() => {
-                  navigation.navigate('PostingDetail', {
-                    title: itemData.item.title,
-                    description: itemData.item.desc,
-                    userId: itemData.item.userId,
-                    id: itemData.item.id,
-                    category: itemData.item.category,
-                    count: itemData.item.count,
-                    owner: itemData.item.owner,
-                    created_on: itemData.item.created_on,
-                    item_pic: itemData.item.item_pic,
-                    request: itemData.item.request,
-                    in_community: itemData.item.in_community,
-                    moderatorView: props.moderatorView,
-                    location: itemData.item.location,
-                    flagged: itemData.item.flagged,
-                  });
-              }}
-            />
-          </View>
-        );
-    };
+  const renderPostingListItem = itemData => {
+    return(
+      <View style={styles.list}>
+        <PostingListItem
+          title={itemData.item.title}
+          request={itemData.item.request}
+          item_pic={itemData.item.item_pic}
+          in_community={itemData.item.in_community}
+          location={itemData.item.location}
+          flagged={itemData.item.flagged}
+          onSelectPosting={() => {
+            navigation.navigate('PostingDetail', {
+              title: itemData.item.title,
+              description: itemData.item.desc,
+              userId: itemData.item.userId,
+              id: itemData.item.id,
+              category: itemData.item.category,
+              count: itemData.item.count,
+              owner: itemData.item.owner,
+              created_on: itemData.item.created_on,
+              item_pic: itemData.item.item_pic,
+              request: itemData.item.request,
+              in_community: itemData.item.in_community,
+              moderatorView: props.moderatorView,
+              location: itemData.item.location,
+              flagged: itemData.item.flagged,
+            });
+          }}
+        />
+      </View>
+    );
+  };
 
   return(
     <FlatList

--- a/react-native/components/PostingList.js
+++ b/react-native/components/PostingList.js
@@ -5,13 +5,13 @@ import PostingListItem from '../components/PostingListItem';
 import { AuthContext } from '../providers/AuthProvider';
 
 const PostingList = props => {
-  const { navigation } = props;
+  const { navigation, searchText } = props;
   const { user, postings, postings_updated } = useContext(AuthContext);
   const [filteredPostings, setFilteredPostings] = useState([]);
 
   useEffect(() => {
     filterPostings();
-  }, [postings_updated, user.profile.member_of]);
+  }, [props.searchText, postings_updated, user.profile.member_of]);
 
   const filterPostings = filterType => {
     let filtered = postings.filter(posting => {
@@ -24,8 +24,14 @@ const PostingList = props => {
       filtered = filtered.filter(posting =>
         user.profile.saved_postings.includes(posting.id));
     } else if (props.filterType === 'USER') {
-      filtered = postings.filter(posting =>
+      filtered = filtered.filter(posting =>
         posting.owner === user.user.id);
+    }
+
+    if (searchText.length > 0) {
+      filtered = filtered.filter(posting =>
+        posting.title.toLowerCase().includes(
+          searchText.toLowerCase()));
     }
 
     setFilteredPostings(filtered);

--- a/react-native/config/navigation-options.js
+++ b/react-native/config/navigation-options.js
@@ -28,29 +28,8 @@ export const drawerMenuIcon = navigation => {
       );
 };
 
-export const optionsMenuIcon = navigation => {
-  return(
-    <TouchableOpacity
-      style={styles.optionsMenuIcon}
-      onPress={() => {
-        console.log(navigation);
-      }}
-    >
-      <SimpleLineIcons
-        name='options-vertical'
-        size={23}
-        color={Colors.light_shade4}
-      />
-    </TouchableOpacity>
-  );
-};
-
-
 const styles = StyleSheet.create({
   drawerIcon: {
     paddingLeft: 15,
   },
-  optionsMenuIcon: {
-    paddingRight: 15,
-  }
 });

--- a/react-native/navigation/DrawerNav.js
+++ b/react-native/navigation/DrawerNav.js
@@ -7,6 +7,7 @@ import UserPostingStack from './UserPostingStack';
 import SavedPostingStack from './SavedPostingStack';
 import CommunityStack from './CommunityStack';
 import ModeratorStack from './ModeratorStack';
+import SettingsStack from './SettingsStack';
 import DrawerContent from '../components/DrawerContent';
 
 const Drawer = createDrawerNavigator();
@@ -40,6 +41,10 @@ const DrawerNav = props => {
       <Drawer.Screen
         name='Moderator'
         component={ModeratorStack}
+      />
+      <Drawer.Screen
+        name='Settings'
+        component={SettingsStack}
       />
     </Drawer.Navigator>
   );

--- a/react-native/navigation/ProfileCreationStack.js
+++ b/react-native/navigation/ProfileCreationStack.js
@@ -24,11 +24,6 @@ const ProfileCreationStack = props => {
         name='CreateProfile'
         component={ProfileCreationScreen}
       />
-      {/* <Stack.Screen */}
-      {/*   name='JoinCommunity' */}
-      {/*   component={JoinCommunityScreen} */}
-      {/*   options={JoinCommunityScreenOptions} */}
-      {/* /> */}
     </Stack.Navigator>
   );
 

--- a/react-native/navigation/ProfileStack.js
+++ b/react-native/navigation/ProfileStack.js
@@ -6,7 +6,7 @@ import ProfileScreen from '../screens/ProfileScreen';
 import ProfileEditScreen from '../screens/ProfileEditScreen';
 import ProfileCreationScreen from '../screens/ProfileCreationScreen';
 
-import { headerOptions, drawerMenuIcon, optionsMenuIcon } from '../config/navigation-options';
+import { headerOptions, drawerMenuIcon } from '../config/navigation-options';
 
 const Stack = createStackNavigator();
 
@@ -17,7 +17,6 @@ const ProfileStack = props => {
         headerTitle: 'Your Profile',
         ...headerOptions,
         headerLeft: drawerMenuIcon.bind(this, navigation),
-        headerRight: optionsMenuIcon.bind(this, navigation),
     };
 
     const ProfileEditScreenOptions = {

--- a/react-native/navigation/SettingsStack.js
+++ b/react-native/navigation/SettingsStack.js
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import { createStackNavigator } from '@react-navigation/stack';
+
+import { AuthContext } from '../providers/AuthProvider';
+import { headerOptions, drawerMenuIcon } from '../config/navigation-options';
+
+import SettingsScreen from '../screens/SettingsScreen';
+
+const Stack = createStackNavigator();
+
+const SettingsStack = props => {
+  const { navigation } = props;
+  const { user } = useContext(AuthContext);
+
+  const SettingsScreenOptions = {
+    headerTitle: `Settings`,
+    ...headerOptions,
+    headerLeft: drawerMenuIcon.bind(this, navigation),
+  };
+
+
+  return(
+    <Stack.Navigator
+      initialRouteName='Settings'
+    >
+      <Stack.Screen
+        name='Settings'
+        component={SettingsScreen}
+        options={SettingsScreenOptions}
+      />
+    </Stack.Navigator>
+  );
+};
+
+export default SettingsStack;

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@react-native-community/image-editor": "^2.3.0",
     "@react-native-community/masked-view": "0.1.6",
+    "@react-native-community/slider": "^3.0.3",
     "@react-navigation/bottom-tabs": "^5.5.2",
     "@react-navigation/drawer": "^5.8.2",
     "@react-navigation/native": "^5.5.0",

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -254,7 +254,7 @@ export const AuthProvider = props => {
             updatedPostings[updatedPostingIndex] = updatedPosting;
             dispatch({
                 type: UPDATE_POSTINGS,
-                postings: loginState.postings,
+                postings: updatedPostings,
                 postings_updated: Math.random(),
             });
         }
@@ -273,18 +273,22 @@ export const AuthProvider = props => {
         });
     };
 
-    const deletePosting = postToDelete => {
-        console.log('deleting one posting with id: ' + updatedPosting.id);
+    const deletePosting = postID => {
+        console.log('deleting one posting with id: ' + postID);
 
         const updatedPostings = loginState.postings;
 
         const deletedPostingIndex = loginState.postings.indexOf(
-            updatedPostings.find(posting => posting.id === updatedPosting.id)
+            updatedPostings.find(posting => posting.id === postID)
         );
 
         if (deletedPostingIndex !== -1) {
             updatedPostings.splice(deletedPostingIndex, 1);
-            dispatch({ type: UPDATE_POSTINGS, postings: loginState.postings });
+            dispatch({
+                type: UPDATE_POSTINGS,
+                postings: updatedPostings,
+                postings_updated: Math.random(),
+            });
         }
     };
 
@@ -375,6 +379,7 @@ export const AuthProvider = props => {
               updatePostings,
               updateOnePosting,
               addPosting,
+              deletePosting,
               autoLogin: handleAutoLogin,
               login: handleLogin,
               logout: handleLogout,

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -181,7 +181,7 @@ export const AuthProvider = props => {
         }).catch(error => {
             console.log(error);
         });
-    }
+    };
 
     const performAuthRequest = (requestType, userData, url) => {
 
@@ -224,17 +224,48 @@ export const AuthProvider = props => {
     const updateProfile = newProfileData => {
         console.log('updating profile');
         dispatch({ type: UPDATE_PROFILE, updatedProfile: newProfileData });
-    }
+    };
 
     const updateUser = newUserData => {
         console.log('updating user');
         dispatch({ type: UPDATE_USER, updatedUser: newUserData });
-    }
+    };
 
     const updatePostings = newPostingsData => {
         console.log('updating postings');
         dispatch({ type: UPDATE_POSTINGS, postings: newPostingsData });
-    }
+    };
+
+    const updateOnePosting = updatedPosting => {
+        console.log('updating one posting with id: ' + updatedPosting.id);
+
+        const updatedPostings = loginState.postings;
+
+        const updatedPostingIndex = loginState.postings.indexOf(
+            updatedPostings.find(posting => posting.id === updatedPosting.id)
+        );
+
+        console.log(updatedPostingIndex);
+        if (updatedPostingIndex !== -1) {
+            updatedPostings[updatedPostingIndex] = updatedPosting;
+            dispatch({ type: UPDATE_POSTINGS, postings: loginState.postings });
+        }
+    };
+
+    const deletePosting = postToDelete => {
+        console.log('deleting one posting with id: ' + updatedPosting.id);
+
+        const updatedPostings = loginState.postings;
+
+        const deletedPostingIndex = loginState.postings.indexOf(
+            updatedPostings.find(posting => posting.id === updatedPosting.id)
+        );
+
+        if (deletedPostingIndex !== -1) {
+            updatedPostings.splice(deletedPostingIndex, 1);
+            dispatch({ type: UPDATE_POSTINGS, postings: loginState.postings });
+        }
+    };
 
     const handleAutoLogin = () => {
         fetchPostings();
@@ -320,6 +351,7 @@ export const AuthProvider = props => {
               updateProfile,
               updateUser,
               updatePostings,
+              updateOnePosting,
               autoLogin: handleAutoLogin,
               login: handleLogin,
               logout: handleLogout,

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -260,6 +260,19 @@ export const AuthProvider = props => {
         }
     };
 
+    const addPosting = newPosting => {
+        console.log('Adding new posting with id: ' + newPosting.id);
+
+        const updatedPostings = loginState.postings;
+        updatedPostings.push(newPosting);
+
+        dispatch({
+            type: UPDATE_POSTINGS,
+            postings: updatedPostings,
+            postings_updated: Math.random(),
+        });
+    };
+
     const deletePosting = postToDelete => {
         console.log('deleting one posting with id: ' + updatedPosting.id);
 
@@ -361,6 +374,7 @@ export const AuthProvider = props => {
               updateUser,
               updatePostings,
               updateOnePosting,
+              addPosting,
               autoLogin: handleAutoLogin,
               login: handleLogin,
               logout: handleLogout,

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -28,11 +28,10 @@ export const AuthProvider = props => {
         user: null,
         communities: null,
         postings: null,
-        updated: false,
+        postings_updated: 0,
     };
 
-    const loginReducer = (previousState, action) => {
-        switch(action.type) {
+    const loginReducer = (previousState, action) => {switch(action.type) {
             case AUTO_LOGIN:
                 return {
                     ...previousState,
@@ -100,6 +99,7 @@ export const AuthProvider = props => {
                     ...previousState,
                     postings: action.postings,
                     isLoading: false,
+                    postings_updated: action.postings_updated,
                 };
         }
     };
@@ -233,7 +233,11 @@ export const AuthProvider = props => {
 
     const updatePostings = newPostingsData => {
         console.log('updating postings');
-        dispatch({ type: UPDATE_POSTINGS, postings: newPostingsData });
+        dispatch({
+            type: UPDATE_POSTINGS,
+            postings: newPostingsData,
+            postings_updated: Math.random(),
+        });
     };
 
     const updateOnePosting = updatedPosting => {
@@ -248,7 +252,11 @@ export const AuthProvider = props => {
         console.log(updatedPostingIndex);
         if (updatedPostingIndex !== -1) {
             updatedPostings[updatedPostingIndex] = updatedPosting;
-            dispatch({ type: UPDATE_POSTINGS, postings: loginState.postings });
+            dispatch({
+                type: UPDATE_POSTINGS,
+                postings: loginState.postings,
+                postings_updated: Math.random(),
+            });
         }
     };
 
@@ -348,6 +356,7 @@ export const AuthProvider = props => {
               user: loginState.user,
               communities: loginState.communities,
               postings: loginState.postings,
+              postings_updated: loginState.postings_updated,
               updateProfile,
               updateUser,
               updatePostings,

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -33,6 +33,7 @@ export const AuthProvider = props => {
         postingsRadius: null,
         postings_updated: 0,
         searchMethod: 'COMMUNITY',
+        searchMethodChanged: 0,
         searchRadius: 10,
     };
 
@@ -112,6 +113,7 @@ export const AuthProvider = props => {
                     ...previousState,
                     searchMethod: action.searchMethod,
                     searchRadius: action.searchRadius,
+                    searchMethodChanged: action.searchMethodChanged,
                 }
         }
     };
@@ -377,11 +379,22 @@ export const AuthProvider = props => {
 
     const setSearchMethod = (method, radius) => {
         console.log('Setting search method: ' + method + ' with radius: ' + radius);
-        dispatch({
-            type: SET_SEARCH_METHOD,
-            searchMethod: method,
-            searchRadius: radius,
-        });
+
+        if (radius === loginState.radius) {
+            dispatch({
+                type: SET_SEARCH_METHOD,
+                searchMethod: method,
+                searchRadius: radius,
+                searchMethodChanged: loginState.searchMethodChanged,
+            });
+        } else {
+            dispatch({
+                type: SET_SEARCH_METHOD,
+                searchMethod: method,
+                searchRadius: radius,
+                searchMethodChanged: Math.random(),
+            });
+        }
     };
 
     return (
@@ -397,6 +410,7 @@ export const AuthProvider = props => {
               postings_updated: loginState.postings_updated,
               searchMethod: loginState.searchMethod,
               searchRadius: loginState.searchRadius,
+              searchMethodChanged: loginState.searchMethodChanged,
               setSearchMethod,
               updateProfile,
               updateUser,

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -13,6 +13,7 @@ const UPDATE_PROFILE = 'UPDATE_PROFILE';
 const UPDATE_USER = 'UPDATE_USER';
 const UPDATE_COMMUNITIES = 'UPDATE_COMMUNITIES';
 const UPDATE_POSTINGS = 'UPDATE_POSTINGS';
+const SET_SEARCH_METHOD = 'SET_SEARCH_METHOD';
 
 // Provides token and login/logout functionality to Global App Context
 // Allows the app to know which user is using it and to handle login/logout
@@ -29,6 +30,8 @@ export const AuthProvider = props => {
         communities: null,
         postings: null,
         postings_updated: 0,
+        searchMethod: 'COMMUNITY',
+        searchRadius: 10,
     };
 
     const loginReducer = (previousState, action) => {switch(action.type) {
@@ -101,6 +104,12 @@ export const AuthProvider = props => {
                     isLoading: false,
                     postings_updated: action.postings_updated,
                 };
+            case SET_SEARCH_METHOD:
+                return {
+                    ...previousState,
+                    searchMethod: action.searchMethod,
+                    searchRadius: action.searchRadius,
+                }
         }
     };
 
@@ -363,6 +372,15 @@ export const AuthProvider = props => {
         dispatch({ type: SET_IS_LOADING, isLoading: loadingStatus });
     };
 
+    const setSearchMethod = (method, radius) => {
+        console.log('Setting search method: ' + method + ' with radius: ' + radius);
+        dispatch({
+            type: SET_SEARCH_METHOD,
+            searchMethod: method,
+            searchRadius: radius,
+        });
+    };
+
     return (
         <AuthContext.Provider
           value={{
@@ -374,6 +392,9 @@ export const AuthProvider = props => {
               communities: loginState.communities,
               postings: loginState.postings,
               postings_updated: loginState.postings_updated,
+              searchMethod: loginState.searchMethod,
+              searchRadius: loginState.searchRadius,
+              setSearchMethod,
               updateProfile,
               updateUser,
               updatePostings,

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -124,7 +124,7 @@ export const AuthProvider = props => {
                 console.log(postingsData.length + ' postings fetched');
                 dispatch({ type: UPDATE_POSTINGS, postings: postingsData });
             } else {
-                console.log("Postings NOT in AsyncStorage, fetching from server...");
+                console.log("Postings NOT in AsyncStorage, fetching from server with method: " + loginState.searchMethod);
 
                 fetch(postings_url, {
                     method: 'GET',

--- a/react-native/providers/AuthProvider.js
+++ b/react-native/providers/AuthProvider.js
@@ -13,6 +13,7 @@ const UPDATE_PROFILE = 'UPDATE_PROFILE';
 const UPDATE_USER = 'UPDATE_USER';
 const UPDATE_COMMUNITIES = 'UPDATE_COMMUNITIES';
 const UPDATE_POSTINGS = 'UPDATE_POSTINGS';
+const UPDATE_RADIUS_POSTINGS = ''
 const SET_SEARCH_METHOD = 'SET_SEARCH_METHOD';
 
 // Provides token and login/logout functionality to Global App Context
@@ -29,12 +30,14 @@ export const AuthProvider = props => {
         user: null,
         communities: null,
         postings: null,
+        postingsRadius: null,
         postings_updated: 0,
         searchMethod: 'COMMUNITY',
         searchRadius: 10,
     };
 
-    const loginReducer = (previousState, action) => {switch(action.type) {
+    const loginReducer = (previousState, action) => {
+        switch(action.type) {
             case AUTO_LOGIN:
                 return {
                     ...previousState,

--- a/react-native/screens/EditPostingScreen.js
+++ b/react-native/screens/EditPostingScreen.js
@@ -47,25 +47,10 @@ const handleUpdatePosting = async (url, data) => {
     });
 };
 
-const handleDeletePosting = async (url) => {
-  showModal('DELETE_POSTING');
-
-  return fetch(url, {
-    method: 'DELETE',
-  }).then(response => {
-    console.log(response.status);
-    return response.json();
-  }).then(json => {
-    // console.log(json);
-  }).finally(() => {
-    hideModal();
-    notifyMessage('Posting Deleted Successfully!');
-  });
-};
 
 const EditPostingScreen = props => {
   const { route, navigation } = props;
-  const { communities, user } = useContext(AuthContext);
+  const { communities, user, deletePosting } = useContext(AuthContext);
   const availableCommunities = communities.filter(community => user.profile.member_of.includes(community.id));
 
   const isAndroid = Platform.OS === 'android' ? true : false;
@@ -106,9 +91,22 @@ const EditPostingScreen = props => {
     navigation.setParams({submitEditPosting});
   }, []);
 
+  const handleDeletePosting = async (url, id) => {
+    showModal('DELETE_POSTING');
+
+    return fetch(url, {
+      method: 'DELETE',
+    }).finally(() => {
+      deletePosting(id);
+      hideModal();
+      navigation.goBack();
+      notifyMessage('Posting Deleted Successfully!');
+    });
+  };
+
   const submitDeletePosting = () => {
-    handleDeletePosting(postingPatchUrl);
-    navigation.navigate('Feed');
+    handleDeletePosting(postingPatchUrl, route.params.id);
+    navigation.goBack();
   }
 
   const createFormData = () => {

--- a/react-native/screens/FlaggedPostingsScreen.js
+++ b/react-native/screens/FlaggedPostingsScreen.js
@@ -18,18 +18,13 @@ import { postings_url } from '../config/urls';
 const FlaggedPostingsScreen = props => {
     const { navigation } = props;
     const { user, communities, postings, updatePostings } = useContext(AuthContext);
-    const [isLoading, setIsLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(false);
 
     const [filteredPostings, setFilteredPostings] = useState([]);
     const [searchPostings, setSearchPostings] = useState([]);
     const [searchText, setSearchText] = useState('');
     const searchInputRef = useRef(null);
  
-  
-    useEffect(() => {
-        filterPostings();
-    }, [postings, user]);
-
     const fetchPostings = () => {
         setIsLoading(true);
 
@@ -47,17 +42,6 @@ const FlaggedPostingsScreen = props => {
           .finally(() => {
               setIsLoading(false)
           });
-    };
-
-    const filterPostings = () => {
-        // filter postings by whether they are flagged
-        let filtered = postings.filter(posting => {
-            return posting.flagged > 0;
-        });
-
-        setFilteredPostings(filtered);
-        setSearchPostings(filteredPostings);
-        setIsLoading(false);
     };
 
     const handleSearch = text => {
@@ -83,6 +67,7 @@ const FlaggedPostingsScreen = props => {
               isLoading={isLoading}
               onRefresh={fetchPostings}
               moderatorView={true}
+              filterType='FLAGGED'
              />
 
     return(

--- a/react-native/screens/FlaggedPostingsScreen.js
+++ b/react-native/screens/FlaggedPostingsScreen.js
@@ -19,9 +19,6 @@ const FlaggedPostingsScreen = props => {
     const { navigation } = props;
     const { user, communities, postings, updatePostings } = useContext(AuthContext);
     const [isLoading, setIsLoading] = useState(false);
-
-    const [filteredPostings, setFilteredPostings] = useState([]);
-    const [searchPostings, setSearchPostings] = useState([]);
     const [searchText, setSearchText] = useState('');
     const searchInputRef = useRef(null);
  
@@ -46,27 +43,20 @@ const FlaggedPostingsScreen = props => {
 
     const handleSearch = text => {
         setSearchText(text);
-
-        let filtered = filteredPostings.filter(posting =>
-            posting.title.toLowerCase().includes(text.toLowerCase())
-        );
-
-        setSearchPostings(filtered);
     };
 
     const handleClearSearchInput = () => {
         setSearchText('');
-        setSearchPostings(filteredPostings);
         searchInputRef.current.clear();
     };
 
     const PostingListSection = isLoading ? <ActivityIndicator size='large'/>
           : <PostingList
-              postings={searchPostings}
               navigation={navigation}
               isLoading={isLoading}
               onRefresh={fetchPostings}
               moderatorView={true}
+              searchText={searchText}
               filterType='FLAGGED'
              />
 

--- a/react-native/screens/FlaggedPostingsScreen.js
+++ b/react-native/screens/FlaggedPostingsScreen.js
@@ -17,7 +17,7 @@ import { postings_url } from '../config/urls';
 
 const FlaggedPostingsScreen = props => {
     const { navigation } = props;
-    const { user, communities, postings, updatePostings } = useContext(AuthContext);
+    const { user, updatePostings } = useContext(AuthContext);
     const [isLoading, setIsLoading] = useState(false);
     const [searchText, setSearchText] = useState('');
     const searchInputRef = useRef(null);

--- a/react-native/screens/FlaggedPostingsScreen.js
+++ b/react-native/screens/FlaggedPostingsScreen.js
@@ -17,17 +17,18 @@ import { postings_url } from '../config/urls';
 
 const FlaggedPostingsScreen = props => {
     const { navigation } = props;
-    const { user, communities } = useContext(AuthContext);
+    const { user, communities, postings, updatePostings } = useContext(AuthContext);
     const [isLoading, setIsLoading] = useState(true);
-    const [postings, setPostings] = useState([]);
+
+    const [filteredPostings, setFilteredPostings] = useState([]);
     const [searchPostings, setSearchPostings] = useState([]);
     const [searchText, setSearchText] = useState('');
     const searchInputRef = useRef(null);
-
-
+ 
+  
     useEffect(() => {
-        fetchPostings();
-    }, [user]);
+        filterPostings();
+    }, [postings, user]);
 
     const fetchPostings = () => {
         setIsLoading(true);
@@ -39,41 +40,39 @@ const FlaggedPostingsScreen = props => {
                 'Content-type': 'application/json',
                 'Access-Control-Allow-Origin': '*',
             }
-        })
-            .then(response => response.json())
-            .then(json => {
-                filterPostings(json);
-            })
-            .catch(error => console.log(error))
-            .finally(() => {
-                setIsLoading(false)
-            });
-
+        }).then(response => response.json())
+          .then(json => {
+              updatePostings(json);
+          })
+          .finally(() => {
+              setIsLoading(false)
+          });
     };
 
-    const filterPostings = postings => {
+    const filterPostings = () => {
         // filter postings by whether they are flagged
-        let filteredPostings = postings.filter(posting => {
+        let filtered = postings.filter(posting => {
             return posting.flagged > 0;
         });
 
-        setPostings(filteredPostings);
+        setFilteredPostings(filtered);
         setSearchPostings(filteredPostings);
+        setIsLoading(false);
     };
 
     const handleSearch = text => {
         setSearchText(text);
 
-        let filteredPostings = postings.filter(posting =>
+        let filtered = filteredPostings.filter(posting =>
             posting.title.toLowerCase().includes(text.toLowerCase())
         );
 
-        setSearchPostings(filteredPostings);
+        setSearchPostings(filtered);
     };
 
     const handleClearSearchInput = () => {
         setSearchText('');
-        setSearchPostings(postings);
+        setSearchPostings(filteredPostings);
         searchInputRef.current.clear();
     };
 
@@ -84,7 +83,7 @@ const FlaggedPostingsScreen = props => {
               isLoading={isLoading}
               onRefresh={fetchPostings}
               moderatorView={true}
-            />
+             />
 
     return(
         <View style={styles.screen}>

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -79,7 +79,7 @@ const PostingCreationScreen = props => {
   const createFormData = values => {
     const categoryValue = isGoodSelected ? 'goods' : 'services';
     const requestValue = isRequestSelected ? true : false;
-    const location = selectedCommunity.location;
+    const location = user.profile.home_location || selectedCommunity.location;
 
     const data = new FormData();
 

--- a/react-native/screens/PostingCreationScreen.js
+++ b/react-native/screens/PostingCreationScreen.js
@@ -29,7 +29,7 @@ const isAndroid = Platform.OS === 'android';
 
 const PostingCreationScreen = props => {
   const { navigation } = props;
-  const { user, communities } = useContext(AuthContext);
+  const { user, communities, addPosting } = useContext(AuthContext);
   const homeCommunity = communities.find(community => community.id === user.profile.home);
   const availableCommunities = communities.filter(community => user.profile.member_of.includes(community.id));
 
@@ -120,6 +120,7 @@ const PostingCreationScreen = props => {
       .then(json => {
         console.log('Post Request: \n')
         console.log(json);
+        addPosting(json);
         notifyMessage('Posting Sucessfully Created!');
         resetFormState();
         navigateToHomeStack();

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -34,7 +34,7 @@ const requestedItemIconImage = '../assets/requested_item.png';
 const itemPlaceHolder = '../assets/image_place_holder.jpg';
 
 const PostingDetailScreen = props => {
-  const { user, updateProfile, postings, updateOnePosting } = useContext(AuthContext);
+  const { user, updateProfile, updateOnePosting } = useContext(AuthContext);
   const { route, navigation } = props;
   const [postingImage, setPostingImage] = useState(null);
   const [isProcessing, setIsProcessing] = useState(false);

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -337,6 +337,7 @@ const PostingDetailScreen = props => {
       <Map
         radius={3000}
         location={route.params.location}
+        hide_point={true}
       />
 
       { renderBottomButton() }

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -38,7 +38,6 @@ const PostingDetailScreen = props => {
   const { route, navigation } = props;
   const [postingImage, setPostingImage] = useState(null);
   const [isProcessing, setIsProcessing] = useState(false);
-  const radius = 4000;
   const picUrl = route.params.item_pic;
   const isModeratorView = route.params.moderatorView;
   const isOwned = user.user.id === route.params.owner;

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -195,10 +195,10 @@ const PostingDetailScreen = props => {
     fetch(url, {
       method: 'DELETE',
     }).then(response => {
-      if (response.ok) {
+      if (response.status === 204) {
         return response.json();
       } else {
-        throw Error(response.text());
+        throw Error(response.json());
       }
     }).then(json => {
       hideModal();

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -110,7 +110,6 @@ const PostingDetailScreen = props => {
   };
 
   const handleFlagPost = () => {
-    showModal('FLAGGING_POSTING');
     const url = postings_url + route.params.id + '/';
 
     let flag = route.params.flagged;
@@ -132,9 +131,6 @@ const PostingDetailScreen = props => {
       // console.log("Server response after flagging post: ");
       // console.log(json);
       updateOnePosting(json);
-      hideModal();
-      notifyMessage('Posting Flagged Successfully!');
-      navigation.goBack();
     });
   };
 

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -332,7 +332,7 @@ const PostingDetailScreen = props => {
       </View>
 
       <View style={styles.descriptionContainer}>
-        <Text style={styles.bodyText}>{route.params.description}</Text>
+        <Text style={styles.bodyText}>{route.params.desc}</Text>
       </View>
 
       <Map

--- a/react-native/screens/PostingDetailScreen.js
+++ b/react-native/screens/PostingDetailScreen.js
@@ -11,9 +11,7 @@ import { View,
          ActivityIndicator,
          Platform,
        } from 'react-native';
-import { AntDesign } from '@expo/vector-icons';
-import { Entypo } from '@expo/vector-icons';
-import { Ionicons } from '@expo/vector-icons';
+import { AntDesign, Entypo, Ionicons } from '@expo/vector-icons';
 import OptionsMenu from "react-native-options-menu";
 
 import { RFValue, RFPercentage } from "react-native-responsive-fontsize";
@@ -36,7 +34,7 @@ const requestedItemIconImage = '../assets/requested_item.png';
 const itemPlaceHolder = '../assets/image_place_holder.jpg';
 
 const PostingDetailScreen = props => {
-  const { user, updateProfile } = useContext(AuthContext);
+  const { user, updateProfile, postings, updateOnePosting } = useContext(AuthContext);
   const { route, navigation } = props;
   const [postingImage, setPostingImage] = useState(null);
   const [isProcessing, setIsProcessing] = useState(false);
@@ -48,7 +46,6 @@ const PostingDetailScreen = props => {
 
 
   useLayoutEffect(() => {
-
     if (!isOwned && !isModeratorView) {
 
       const isFavorited = user.profile.saved_postings.includes(route.params.id);
@@ -113,6 +110,7 @@ const PostingDetailScreen = props => {
   };
 
   const handleFlagPost = () => {
+    showModal('FLAGGING_POSTING');
     const url = postings_url + route.params.id + '/';
 
     let flag = route.params.flagged;
@@ -128,11 +126,15 @@ const PostingDetailScreen = props => {
       },
       body: JSON.stringify(payload),
     }).then(response => {
-      console.log("Server Response: " + response.status);
+      // console.log("Server Response: " + response.status);
       return response.json();
     }).then(json => {
-      console.log("Server response after flagging post: ");
-      console.log(json);
+      // console.log("Server response after flagging post: ");
+      // console.log(json);
+      updateOnePosting(json);
+      hideModal();
+      notifyMessage('Posting Flagged Successfully!');
+      navigation.goBack();
     });
   };
 
@@ -230,6 +232,7 @@ const PostingDetailScreen = props => {
     }).then(json => {
       hideModal();
       notifyMessage('Posting un-flagged Successfully!');
+      updateOnePosting(json);
       navigation.goBack();
     }).catch(error => {
       console.log(JSON.stringify(error));

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -19,12 +19,17 @@ import { postings_url } from '../config/urls';
 const Feed = props => {
   const { navigation } = props;
   const { user, communities, postings, updatePostings } = useContext(AuthContext);
+
   const [isLoading, setIsLoading] = useState(true);
-  // const [postings, setPostings] = useState([]);
   const [filteredPostings, setFilteredPostings] = useState([]);
   const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
+
+  useEffect(() => {
+    filterPostings(postings);
+  }, [user.profile.member_of, postings]);
+
 
   const fetchPostings = () => {
     setIsLoading(true);
@@ -39,7 +44,6 @@ const Feed = props => {
     })
       .then(response => response.json())
       .then(json => {
-        // filterPostings(json);
         updatePostings(json);
       })
       .catch(error => console.log(error))
@@ -54,16 +58,11 @@ const Feed = props => {
       return user.profile.member_of.includes(posting.in_community);
     });
 
-    // setPostings(filteredPostings);
     setFilteredPostings(filtered);
     setSearchPostings(filtered);
     setIsLoading(false);
   };
 
-  useEffect(() => {
-    // fetchPostings();
-    filterPostings(postings);
-  }, [user.profile.member_of]);
 
   const handleSearch = text => {
     setSearchText(text);

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -31,6 +31,7 @@ const Feed = props => {
   const fetchPostings = () => {
     setIsLoading(true);
 
+    console.log(searchMethod);
     const url = searchMethod === 'COMMUNITY' ? postings_url : generateRadiusUrl();
 
     fetch(url, {

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -48,9 +48,14 @@ const Feed = props => {
   };
 
   const generateRadiusUrl = () => {
+    const loc = user.profile.home_location;
+    const longitude = loc.slice(loc.indexOf('(') + 1, loc.lastIndexOf(' '));
+    const latitude = loc.slice(loc.lastIndexOf(' ') + 1, loc.indexOf(')'));
+
     let url = postings_url;
-    url += '?longitude=' + '-122.084' + '&latitude=' + '37.4219983' + '&radius=' + searchRadius;
+    url += '?longitude=' + longitude + '&latitude=' + latitude + '&radius=' + searchRadius;
     console.log(url);
+
     return url;
   };
 

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -20,15 +20,10 @@ const Feed = props => {
   const { navigation } = props;
   const { user, communities, postings, updatePostings } = useContext(AuthContext);
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [filteredPostings, setFilteredPostings] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
   const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
-
-  useEffect(() => {
-    filterPostings();
-  }, [user.profile.member_of, postings]);
 
   const fetchPostings = () => {
     setIsLoading(true);
@@ -50,18 +45,6 @@ const Feed = props => {
         setIsLoading(false)
       });
   };
-
-  const filterPostings = () => {
-    // filter postings by whether it is in the user's member_of list
-    let filtered = postings.filter(posting => {
-      return user.profile.member_of.includes(posting.in_community);
-    });
-
-    setFilteredPostings(filtered);
-    setSearchPostings(filtered);
-    setIsLoading(false);
-  };
-
 
   const handleSearch = text => {
     setSearchText(text);

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -18,7 +18,7 @@ import { postings_url } from '../config/urls';
 
 const Feed = props => {
   const { navigation } = props;
-  const { user, communities, updatePostings } = useContext(AuthContext);
+  const { user, updatePostings, searchMethod, searchRadius } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
   const [searchText, setSearchText] = useState('');
@@ -27,7 +27,9 @@ const Feed = props => {
   const fetchPostings = () => {
     setIsLoading(true);
 
-    fetch(postings_url, {
+    const url = searchMethod === 'COMMUNITY' ? postings_url : generateRadiusUrl();
+
+    fetch(url, {
       method: 'GET',
       headers: {
         'Accept': 'application/json',
@@ -45,6 +47,13 @@ const Feed = props => {
       });
   };
 
+  const generateRadiusUrl = () => {
+    let url = postings_url;
+    url += '?longitude=' + '-122.084' + '&latitude=' + '37.4219983' + '&radius=' + searchRadius;
+    console.log(url);
+    return url;
+  };
+
   const handleSearch = text => {
     setSearchText(text);
   };
@@ -55,7 +64,7 @@ const Feed = props => {
   };
 
   const PostingListSection = isLoading ? <ActivityIndicator size='large'/>
-          : <PostingList
+        : <PostingList
             navigation={navigation}
             isLoading={isLoading}
             onRefresh={fetchPostings}
@@ -63,36 +72,36 @@ const Feed = props => {
           />
 
   return(
-       <View style={styles.screen}>
-          <View style={styles.searchContainer}>
-            <View style={styles.inputView}>
-              <Ionicons
-                name={'ios-search'}
-                size={23}
-                style={styles.inputIcon}
-              />
-              <TextInput
-                style={styles.inputText}
-                placeholder='Search for an item'
-                placeholderTextColor={Colors.placeholder_text}
-                autoCapitalize='none'
-                onChangeText={text => handleSearch(text)}
-                returnKeyType='done'
-                ref={searchInputRef}
-              />
-              <TouchableOpacity
-                style={styles.inputIcon}
-                onPress={() => handleClearSearchInput()}
-              >
-                <Feather
-                  name={'x-circle'}
-                  size={20}
-                />
-              </TouchableOpacity>
-            </View>
-          </View>
-         {PostingListSection}
+    <View style={styles.screen}>
+      <View style={styles.searchContainer}>
+        <View style={styles.inputView}>
+          <Ionicons
+            name={'ios-search'}
+            size={23}
+            style={styles.inputIcon}
+          />
+          <TextInput
+            style={styles.inputText}
+            placeholder='Search for an item'
+            placeholderTextColor={Colors.placeholder_text}
+            autoCapitalize='none'
+            onChangeText={text => handleSearch(text)}
+            returnKeyType='done'
+            ref={searchInputRef}
+          />
+          <TouchableOpacity
+            style={styles.inputIcon}
+            onPress={() => handleClearSearchInput()}
+          >
+            <Feather
+              name={'x-circle'}
+              size={20}
+            />
+          </TouchableOpacity>
         </View>
+      </View>
+      {PostingListSection}
+    </View>
   );
 };
 

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -18,11 +18,15 @@ import { postings_url } from '../config/urls';
 
 const Feed = props => {
   const { navigation } = props;
-  const { user, updatePostings, searchMethod, searchRadius } = useContext(AuthContext);
+  const { user, updatePostings, searchMethod, searchRadius, searchMethodChanged } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
+
+  useEffect(() => {
+    fetchPostings();
+  }, [searchMethodChanged]);
 
   const fetchPostings = () => {
     setIsLoading(true);

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -21,7 +21,6 @@ const Feed = props => {
   const { user, communities, postings, updatePostings } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
 
@@ -48,26 +47,19 @@ const Feed = props => {
 
   const handleSearch = text => {
     setSearchText(text);
-
-    let filtered = filteredPostings.filter(posting =>
-      posting.title.toLowerCase().includes(text.toLowerCase())
-    );
-
-    setSearchPostings(filtered);
   };
 
   const handleClearSearchInput = () => {
     setSearchText('');
-    setSearchPostings(filteredPostings);
     searchInputRef.current.clear();
   };
 
   const PostingListSection = isLoading ? <ActivityIndicator size='large'/>
           : <PostingList
-            postings={searchPostings}
             navigation={navigation}
             isLoading={isLoading}
             onRefresh={fetchPostings}
+            searchText={searchText}
           />
 
   return(

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -18,7 +18,7 @@ import { postings_url } from '../config/urls';
 
 const Feed = props => {
   const { navigation } = props;
-  const { user, communities, postings, updatePostings } = useContext(AuthContext);
+  const { user, communities, updatePostings } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
   const [searchText, setSearchText] = useState('');

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -18,16 +18,17 @@ import { postings_url } from '../config/urls';
 
 const Feed = props => {
   const { navigation } = props;
-  const { user, communities } = useContext(AuthContext);
+  const { user, communities, postings, updatePostings } = useContext(AuthContext);
   const [isLoading, setIsLoading] = useState(true);
-  const [postings, setPostings] = useState([]);
+  // const [postings, setPostings] = useState([]);
+  const [filteredPostings, setFilteredPostings] = useState([]);
   const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
 
   const fetchPostings = () => {
     setIsLoading(true);
-   
+
     fetch(postings_url, {
       method: 'GET',
       headers: {
@@ -38,36 +39,40 @@ const Feed = props => {
     })
       .then(response => response.json())
       .then(json => {
-        filterPostings(json);
+        // filterPostings(json);
+        updatePostings(json);
       })
       .catch(error => console.log(error))
       .finally(() => {
         setIsLoading(false)
       });
+  };
 
-    const filterPostings = postings => {
-      // filter postings by whether it is in the user's member_of list
-      let filteredPostings = postings.filter(posting => {
-        return user.profile.member_of.includes(posting.in_community);
-      });
+  const filterPostings = postings => {
+    // filter postings by whether it is in the user's member_of list
+    let filtered = postings.filter(posting => {
+      return user.profile.member_of.includes(posting.in_community);
+    });
 
-      setPostings(filteredPostings);
-      setSearchPostings(filteredPostings);
-    }
+    // setPostings(filteredPostings);
+    setFilteredPostings(filtered);
+    setSearchPostings(filtered);
+    setIsLoading(false);
   };
 
   useEffect(() => {
-    fetchPostings();
+    // fetchPostings();
+    filterPostings(postings);
   }, [user.profile.member_of]);
 
   const handleSearch = text => {
     setSearchText(text);
 
-    let filteredPostings = postings.filter(posting =>
+    let filtered = postings.filter(posting =>
       posting.title.toLowerCase().includes(text.toLowerCase())
     );
 
-    setSearchPostings(filteredPostings);
+    setSearchPostings(filtered);
   };
 
   const handleClearSearchInput = () => {

--- a/react-native/screens/PostingListScreen.js
+++ b/react-native/screens/PostingListScreen.js
@@ -27,9 +27,8 @@ const Feed = props => {
   const searchInputRef = useRef(null);
 
   useEffect(() => {
-    filterPostings(postings);
+    filterPostings();
   }, [user.profile.member_of, postings]);
-
 
   const fetchPostings = () => {
     setIsLoading(true);
@@ -52,7 +51,7 @@ const Feed = props => {
       });
   };
 
-  const filterPostings = postings => {
+  const filterPostings = () => {
     // filter postings by whether it is in the user's member_of list
     let filtered = postings.filter(posting => {
       return user.profile.member_of.includes(posting.in_community);
@@ -67,7 +66,7 @@ const Feed = props => {
   const handleSearch = text => {
     setSearchText(text);
 
-    let filtered = postings.filter(posting =>
+    let filtered = filteredPostings.filter(posting =>
       posting.title.toLowerCase().includes(text.toLowerCase())
     );
 
@@ -76,7 +75,7 @@ const Feed = props => {
 
   const handleClearSearchInput = () => {
     setSearchText('');
-    setSearchPostings(postings);
+    setSearchPostings(filteredPostings);
     searchInputRef.current.clear();
   };
 

--- a/react-native/screens/ProfileCreationScreen.js
+++ b/react-native/screens/ProfileCreationScreen.js
@@ -10,24 +10,23 @@ import {
     Platform,
     StyleSheet,
 } from 'react-native';
-
 import { AntDesign, FontAwesome, FontAwesome5, Entypo } from '@expo/vector-icons';
 import KeyboardShift from 'react-native-keyboardshift-razzium';
 import { Formik } from "formik";
 import * as Yup from "yup";
-
 import * as Location from 'expo-location';
 
 import { AuthContext } from '../providers/AuthProvider';
 
 import CustomImagePicker from '../components/CustomImagePicker';
 import CustomButton from '../components/CustomButton';
-
 import CommunityPicker from '../components/CommunityPicker';
 import Colors from '../config/colors';
+
 import { showModal, hideModal } from '../components/CustomModal';
 import { windowHeight, windowWidth } from '../config/dimensions';
 import { users_url, profiles_url } from '../config/urls';
+
 const isAndroid = Platform.OS === 'android' ? true : false;
 
 const ProfileCreationScreen = props => {

--- a/react-native/screens/ProfileCreationScreen.js
+++ b/react-native/screens/ProfileCreationScreen.js
@@ -37,11 +37,11 @@ const ProfileCreationScreen = props => {
     const [selectedCommunity, setSelectedCommunity] = useState(communities[0]);
     const [selectedImage, setSelectedImage] = useState(null);
     const [isProcessing, setIsProcessing] = useState(false);
+    const [location, setLocation] = useState(null);
 
     const firstNameRef = useRef(null);
     const lastNameRef = useRef(null);
     const profileTextRef = useRef(null);
-    const [ location, setLocation] = useState(null);
 
     const errorIcon = () => (
         <FontAwesome

--- a/react-native/screens/ProfileScreen.js
+++ b/react-native/screens/ProfileScreen.js
@@ -114,10 +114,16 @@ const ProfileScreen = props => {
         <Text style={styles.labelText}>Home</Text>
         <Text style={styles.text}>{homeCommunity.name}</Text>
       </View>
+
+      {
+        user.profile.home_location ?
         <Map
-          radius={3000}
+          radius={2000}
           location={user.profile.home_location}
+          no_circle={true}
         />
+        : null
+      }
       <CustomButton
         style={styles.button}
         onPress={() => {

--- a/react-native/screens/ProfileScreen.js
+++ b/react-native/screens/ProfileScreen.js
@@ -47,15 +47,16 @@ const ProfileScreen = props => {
   }, [navigation]);
 
   const handleUpdateLocation = async () => {
-    showModal('UPDATING_LOCATION');
     (async () => {
       let { status } = await Location.requestPermissionsAsync();
       if (status !== 'granted') {
         setErrorMsg('Permission to access location was denied');
+      } else {
+        showModal('UPDATING_LOCATION');
+        let location = await Location.getCurrentPositionAsync({accuracy: 5})
+        console.log(location);
+        await updateProfileWithNewLocation(location);
       }
-      let location = await Location.getCurrentPositionAsync({accuracy: 5})
-      console.log(location);
-      await updateProfileWithNewLocation(location);
     }
     )()
   };

--- a/react-native/screens/ProfileScreen.js
+++ b/react-native/screens/ProfileScreen.js
@@ -1,11 +1,13 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useLayoutEffect } from 'react';
 import {
   View,
   ScrollView,
   Text,
   Image,
+  TouchableOpacity,
   StyleSheet,
 } from 'react-native';
+import { Ionicons, SimpleLineIcons } from '@expo/vector-icons';
 
 import { AuthContext } from '../providers/AuthProvider';
 import CustomButton from '../components/CustomButton';
@@ -22,33 +24,52 @@ const ProfileScreen = props => {
   const picUrl = user.profile.profile_pic ? user.profile.profile_pic : null;
   const homeCommunity = communities.find(community => community.id === user.profile.home) || '';
 
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TouchableOpacity
+          style={styles.optionsMenuIcon}
+          onPress={() => {
+            console.log(navigation);
+          }}
+        >
+          <SimpleLineIcons
+            name='options-vertical'
+            size={23}
+            color={Colors.light_shade4}
+          />
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation]);
+
   return(
     <ScrollView contentContainerStyle={styles.screen}>
-        <Text style={styles.username}>{user.user.username}</Text>
-        <Text style={styles.date}>Member Since: {prettifyDate(user.user.date_joined)}</Text>
+      <Text style={styles.username}>{user.user.username}</Text>
+      <Text style={styles.date}>Member Since: {prettifyDate(user.user.date_joined)}</Text>
 
-        <View style={styles.imageContainer}>
-          <Image
-            style={styles.itemImage}
-            resizeMode='cover'
+      <View style={styles.imageContainer}>
+        <Image
+          style={styles.itemImage}
+          resizeMode='cover'
 
-            source={picUrl !== null
-                    ? {uri:picUrl}
-                    : require(itemPlaceHolder)
-                   }
-          />
-        </View>
+          source={picUrl !== null
+                  ? {uri:picUrl}
+                  : require(itemPlaceHolder)
+                 }
+        />
+      </View>
 
-        <View style={styles.userDetailSection}>
-          <Text style={styles.labelText}>Name</Text>
-          <Text style={styles.text}>{user.user.first_name} {user.user.last_name}</Text>
-          <Text style={styles.labelText}>Email</Text>
-          <Text style={styles.text}>{user.user.email}</Text>
-          <Text style={styles.labelText}>Bio</Text>
-          <Text style={styles.text}>{user.profile.profile_text}</Text>
-          <Text style={styles.labelText}>Home</Text>
-          <Text style={styles.text}>{homeCommunity.name}</Text>
-        </View>
+      <View style={styles.userDetailSection}>
+        <Text style={styles.labelText}>Name</Text>
+        <Text style={styles.text}>{user.user.first_name} {user.user.last_name}</Text>
+        <Text style={styles.labelText}>Email</Text>
+        <Text style={styles.text}>{user.user.email}</Text>
+        <Text style={styles.labelText}>Bio</Text>
+        <Text style={styles.text}>{user.profile.profile_text}</Text>
+        <Text style={styles.labelText}>Home</Text>
+        <Text style={styles.text}>{homeCommunity.name}</Text>
+      </View>
       <CustomButton
         style={styles.button}
         onPress={() => {
@@ -111,7 +132,10 @@ const styles = StyleSheet.create({
   },
   date: {
     fontSize: 12,
-  }
+  },
+  optionsMenuIcon: {
+    paddingRight: 15,
+  },
 });
 
 export default ProfileScreen;

--- a/react-native/screens/ProfileScreen.js
+++ b/react-native/screens/ProfileScreen.js
@@ -10,6 +10,7 @@ import {
 import { Entypo } from '@expo/vector-icons';
 import OptionsMenu from "react-native-options-menu";
 import * as Location from 'expo-location';
+import Map from '../components/Map';
 
 import { AuthContext } from '../providers/AuthProvider';
 import CustomButton from '../components/CustomButton';
@@ -113,6 +114,10 @@ const ProfileScreen = props => {
         <Text style={styles.labelText}>Home</Text>
         <Text style={styles.text}>{homeCommunity.name}</Text>
       </View>
+        <Map
+          radius={3000}
+          location={user.profile.home_location}
+        />
       <CustomButton
         style={styles.button}
         onPress={() => {

--- a/react-native/screens/SavedPostingListScreen.js
+++ b/react-native/screens/SavedPostingListScreen.js
@@ -18,7 +18,7 @@ import { AuthContext } from '../providers/AuthProvider';
 
 const SavedPostingListScreen = props => {
   const { navigation } = props;
-  const { user, postings, updatePostings } = useContext(AuthContext);
+  const { user, updatePostings } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
   const [searchText, setSearchText] = useState('');

--- a/react-native/screens/SavedPostingListScreen.js
+++ b/react-native/screens/SavedPostingListScreen.js
@@ -18,16 +18,23 @@ import { AuthContext } from '../providers/AuthProvider';
 
 const SavedPostingListScreen = props => {
   const { navigation } = props;
-  const { user, updatePostings } = useContext(AuthContext);
+  const { user, updatePostings, searchMethod, searchRadius, searchMethodChanged } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
 
+  useEffect(() => {
+    fetchPostings();
+  }, [searchMethodChanged]);
+
   const fetchPostings = () => {
     setIsLoading(true);
 
-    fetch(postings_url, {
+    console.log(searchMethod);
+    const url = searchMethod === 'COMMUNITY' ? postings_url : generateRadiusUrl();
+
+    fetch(url, {
       method: 'GET',
       headers: {
         'Accept': 'application/json',
@@ -39,9 +46,22 @@ const SavedPostingListScreen = props => {
       .then(json => {
         updatePostings(json);
       })
+      .catch(error => console.log(error))
       .finally(() => {
         setIsLoading(false)
       });
+  };
+
+  const generateRadiusUrl = () => {
+    const loc = user.profile.home_location;
+    const longitude = loc.slice(loc.indexOf('(') + 1, loc.lastIndexOf(' '));
+    const latitude = loc.slice(loc.lastIndexOf(' ') + 1, loc.indexOf(')'));
+
+    let url = postings_url;
+    url += '?longitude=' + longitude + '&latitude=' + latitude + '&radius=' + searchRadius;
+    console.log(url);
+
+    return url;
   };
 
   const handleSearch = text => {

--- a/react-native/screens/SavedPostingListScreen.js
+++ b/react-native/screens/SavedPostingListScreen.js
@@ -21,8 +21,6 @@ const SavedPostingListScreen = props => {
   const { user, postings, updatePostings } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [filteredPostings, setFilteredPostings] = useState([]);
-  const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
 
@@ -46,38 +44,21 @@ const SavedPostingListScreen = props => {
       });
   };
 
-  const filterPostings = () => {
-    let savedPostings = postings.filter(posting => user.profile.saved_postings.includes(posting.id));
-    // console.log('Users Postings: ');
-    // console.log(savedPostings);
-
-    setFilteredPostings(savedPostings);
-    setSearchPostings(savedPostings);
-    setIsLoading(false);
-  };
-
   const handleSearch = text => {
     setSearchText(text);
-
-    let filtered = filteredPostings.filter(posting =>
-      posting.title.toLowerCase().includes(text.toLowerCase())
-    );
-
-    setSearchPostings(filtered);
   };
 
   const handleClearSearchInput = () => {
     setSearchText('');
-    setSearchPostings(filteredPostings);
     searchInputRef.current.clear();
   };
 
   const PostingListSection = isLoading ? <ActivityIndicator size='large'/>
         : <PostingList
-            postings={searchPostings}
             navigation={navigation}
             isLoading={isLoading}
             onRefresh={fetchPostings}
+            searchText={searchText}
             filterType='SAVED'
           />
 

--- a/react-native/screens/SavedPostingListScreen.js
+++ b/react-native/screens/SavedPostingListScreen.js
@@ -18,13 +18,17 @@ import { AuthContext } from '../providers/AuthProvider';
 
 const SavedPostingListScreen = props => {
   const { navigation } = props;
-  const { user } = useContext(AuthContext);
+  const { user, postings, updatePostings } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(true);
-  const [postings, setPostings] = useState([]);
+  const [filteredPostings, setFilteredPostings] = useState([]);
   const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
+
+  useEffect(() => {
+    filterPostings(postings);
+  }, [postings, user.profile.saved_postings]);
 
   const fetchPostings = () => {
     setIsLoading(true);
@@ -39,7 +43,7 @@ const SavedPostingListScreen = props => {
     })
       .then(response => response.json())
       .then(json => {
-        filterToSavedPostings(json)
+        updatePostings(json);
       })
       .catch(error => console.log(error))
       .finally(() => {
@@ -47,17 +51,14 @@ const SavedPostingListScreen = props => {
       });
   };
 
-  useEffect(() => {
-    fetchPostings();
-  }, []);
-
-  const filterToSavedPostings = postings => {
+  const filterPostings = postings => {
     let savedPostings = postings.filter(posting => user.profile.saved_postings.includes(posting.id));
     console.log('Users Postings: ');
     console.log(savedPostings);
 
-    setPostings(savedPostings);
+    setFilteredPostings(savedPostings);
     setSearchPostings(savedPostings);
+    setIsLoading(false);
   };
 
   const handleSearch = text => {
@@ -78,11 +79,11 @@ const SavedPostingListScreen = props => {
 
   const PostingListSection = isLoading ? <ActivityIndicator size='large'/>
         : <PostingList
-             postings={searchPostings}
-             navigation={navigation}
-           isLoading={isLoading}
-             onRefresh={fetchPostings}
-           />
+            postings={searchPostings}
+            navigation={navigation}
+            isLoading={isLoading}
+            onRefresh={fetchPostings}
+          />
 
   return(
     <View style={styles.screen}>

--- a/react-native/screens/SavedPostingListScreen.js
+++ b/react-native/screens/SavedPostingListScreen.js
@@ -27,7 +27,7 @@ const SavedPostingListScreen = props => {
   const searchInputRef = useRef(null);
 
   useEffect(() => {
-    filterPostings(postings);
+    filterPostings();
   }, [postings, user.profile.saved_postings]);
 
   const fetchPostings = () => {
@@ -45,16 +45,15 @@ const SavedPostingListScreen = props => {
       .then(json => {
         updatePostings(json);
       })
-      .catch(error => console.log(error))
       .finally(() => {
         setIsLoading(false)
       });
   };
 
-  const filterPostings = postings => {
+  const filterPostings = () => {
     let savedPostings = postings.filter(posting => user.profile.saved_postings.includes(posting.id));
-    console.log('Users Postings: ');
-    console.log(savedPostings);
+    // console.log('Users Postings: ');
+    // console.log(savedPostings);
 
     setFilteredPostings(savedPostings);
     setSearchPostings(savedPostings);
@@ -64,16 +63,16 @@ const SavedPostingListScreen = props => {
   const handleSearch = text => {
     setSearchText(text);
 
-    let filteredPostings = postings.filter(posting =>
+    let filtered = filteredPostings.filter(posting =>
       posting.title.toLowerCase().includes(text.toLowerCase())
     );
 
-    setSearchPostings(filteredPostings);
+    setSearchPostings(filtered);
   };
 
   const handleClearSearchInput = () => {
     setSearchText('');
-    setSearchPostings(postings);
+    setSearchPostings(filteredPostings);
     searchInputRef.current.clear();
   };
 

--- a/react-native/screens/SavedPostingListScreen.js
+++ b/react-native/screens/SavedPostingListScreen.js
@@ -20,15 +20,11 @@ const SavedPostingListScreen = props => {
   const { navigation } = props;
   const { user, postings, updatePostings } = useContext(AuthContext);
 
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [filteredPostings, setFilteredPostings] = useState([]);
   const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
-
-  useEffect(() => {
-    filterPostings();
-  }, [postings, user.profile.saved_postings]);
 
   const fetchPostings = () => {
     setIsLoading(true);
@@ -82,6 +78,7 @@ const SavedPostingListScreen = props => {
             navigation={navigation}
             isLoading={isLoading}
             onRefresh={fetchPostings}
+            filterType='SAVED'
           />
 
   return(

--- a/react-native/screens/SettingsScreen.js
+++ b/react-native/screens/SettingsScreen.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const SettingsScreen = props => {
+    return(
+        <View style={styles.screen}>
+          <Text>Settings Screen</Text>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    screen: {
+        height: '100%',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+});
+
+export default SettingsScreen;

--- a/react-native/screens/SettingsScreen.js
+++ b/react-native/screens/SettingsScreen.js
@@ -1,19 +1,106 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Slider } from 'react-native';
+import { Switch, Card, Paragraph } from 'react-native-paper';
+
+import Colors from '../config/colors';
 
 const SettingsScreen = props => {
+    const [isSwitchOn, setIsSwitchOn] = useState(false);
+    const [sliderValue, setSliderValue] = useState(10);
+
+    const onToggleSwitch = () => setIsSwitchOn(!isSwitchOn);
+
+    const communitySearchText = 'Postings will be fetched from your joined communities';
+    const radiusSearchText = 'Nearby postings will be fetched from a radius around your current location';
+
+    const sliderSection = () => (
+        <View style={styles.sliderSection}>
+          <Text>Radius: {sliderValue}</Text>
+          <Slider
+            style={styles.slider}
+            value={sliderValue}
+            step={1}
+            minimumValue={1}
+            maximumValue={50}
+            onValueChange={value => setSliderValue(value)}
+          />
+        </View>
+    );
+
+    const searchMethodExplanationText = isSwitchOn ? radiusSearchText : communitySearchText;
     return(
         <View style={styles.screen}>
-          <Text>Settings Screen</Text>
+          <Card style={styles.settingsCard}>
+            <Card.Content style={styles.cardContent}>
+              <View style={styles.searchTypeSettingContainer}>
+                <Text style={styles.sectionTitleText}>Search Method</Text>
+                <View style={styles.switchContainer}>
+                  <Text style={styles.switchLabel}>Community</Text>
+                  <Switch
+                    value={isSwitchOn}
+                    onValueChange={onToggleSwitch}
+                    color={Colors.secondary}
+                    style={styles.switch}
+                  />
+                  <Text style={styles.switchLabel}>Location    </Text>
+                </View>
+                { isSwitchOn ? sliderSection() : null}
+                <Paragraph style={styles.paragraphText}>
+                  {searchMethodExplanationText}
+                </Paragraph>
+              </View>
+            </Card.Content>
+          </Card>
         </View>
     );
 };
 
 const styles = StyleSheet.create({
     screen: {
-        height: '100%',
         justifyContent: 'center',
         alignItems: 'center',
+        padding: 20,
+    },
+    settingsCard: {
+        width: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    cardContent: {
+        width: '100%',
+    },
+    searchTypeSettingContainer: {
+        alignItems: 'center',
+    },
+    switchContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingTop: 20,
+        paddingBottom: 10,
+    },
+    switch: {
+            marginHorizontal: 20,
+    },
+    sectionTitleText: {
+        fontSize: 30,
+        fontWeight: 'bold',
+    },
+    switchLabel: {
+        fontSize: 16,
+        fontWeight: 'bold',
+    },
+    paragraphText: {
+        textAlign: 'center',
+        fontSize: 12,
+    },
+    sliderSection: {
+        width: '100%',
+        height: 80,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    slider: {
+        width: '70%',
     },
 });
 

--- a/react-native/screens/SettingsScreen.js
+++ b/react-native/screens/SettingsScreen.js
@@ -1,17 +1,36 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { View, Text, StyleSheet, Slider } from 'react-native';
 import { Switch, Card, Paragraph } from 'react-native-paper';
+
+import { AuthContext } from '../providers/AuthProvider';
 
 import Colors from '../config/colors';
 
 const SettingsScreen = props => {
-    const [isSwitchOn, setIsSwitchOn] = useState(false);
-    const [sliderValue, setSliderValue] = useState(10);
+    const { searchMethod, searchRadius, setSearchMethod } = useContext(AuthContext);
+    const [isSwitchOn, setIsSwitchOn] = useState(
+        searchMethod === 'COMMUNITY' ? false : true
+    );
+    const [radius, setRadius] = useState(searchRadius);
+    const [sliderValue, setSliderValue] = useState(searchRadius);
 
     const onToggleSwitch = () => setIsSwitchOn(!isSwitchOn);
 
     const communitySearchText = 'Postings will be fetched from your joined communities';
     const radiusSearchText = 'Nearby postings will be fetched from a radius around your current location';
+
+    const updateSliderValue = value => {
+        const method = isSwitchOn ? 'RADIUS' : 'COMMUNITY';
+        setRadius(value);
+        setSearchMethod(method, value);
+    };
+
+    const updateSearchMethod = () => {
+        onToggleSwitch();
+        const method = isSwitchOn ? 'COMMUNITY' : 'RADIUS';
+
+        setSearchMethod(method, radius);
+    };
 
     const sliderSection = () => (
         <View style={styles.sliderSection}>
@@ -23,6 +42,7 @@ const SettingsScreen = props => {
             minimumValue={1}
             maximumValue={50}
             onValueChange={value => setSliderValue(value)}
+            onSlidingComplete={value => updateSliderValue(value)}
           />
         </View>
     );
@@ -38,7 +58,7 @@ const SettingsScreen = props => {
                   <Text style={styles.switchLabel}>Community</Text>
                   <Switch
                     value={isSwitchOn}
-                    onValueChange={onToggleSwitch}
+                    onValueChange={updateSearchMethod}
                     color={Colors.secondary}
                     style={styles.switch}
                   />

--- a/react-native/screens/UserPostingListScreen.js
+++ b/react-native/screens/UserPostingListScreen.js
@@ -18,7 +18,7 @@ import { AuthContext } from '../providers/AuthProvider';
 
 const UserPostingListScreen = props => {
   const { navigation } = props;
-  const { user, postings, updatePostings } = useContext(AuthContext);
+  const { user, updatePostings } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
   const [searchText, setSearchText] = useState('');

--- a/react-native/screens/UserPostingListScreen.js
+++ b/react-native/screens/UserPostingListScreen.js
@@ -21,7 +21,6 @@ const UserPostingListScreen = props => {
   const { user, postings, updatePostings } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
 
@@ -45,38 +44,21 @@ const UserPostingListScreen = props => {
       });
   };
 
-  const filterPostings = () => {
-    let filtered = postings.filter(posting => {
-      return posting.owner === user.user.id;
-    });
-
-    setFilteredPostings(filtered);
-    setSearchPostings(filtered);
-    setIsLoading(false);
-  };
-
   const handleSearch = text => {
     setSearchText(text);
-
-    let filtered = filteredPostings.filter(posting =>
-      posting.title.toLowerCase().includes(text.toLowerCase())
-    );
-
-    setSearchPostings(filtered);
   };
 
   const handleClearSearchInput = () => {
     setSearchText('');
-    setSearchPostings(filteredPostings);
     searchInputRef.current.clear();
   };
 
   const PostingListSection = isLoading ? <ActivityIndicator size='large'/>
         : <PostingList
-            postings={searchPostings}
             navigation={navigation}
             isLoading={isLoading}
             onRefresh={fetchPostings}
+            searchText={searchText}
             filterType='USER'
           />
 

--- a/react-native/screens/UserPostingListScreen.js
+++ b/react-native/screens/UserPostingListScreen.js
@@ -18,16 +18,23 @@ import { AuthContext } from '../providers/AuthProvider';
 
 const UserPostingListScreen = props => {
   const { navigation } = props;
-  const { user, updatePostings } = useContext(AuthContext);
+  const { user, updatePostings, searchMethod, searchRadius, searchMethodChanged } = useContext(AuthContext);
 
   const [isLoading, setIsLoading] = useState(false);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
 
+  useEffect(() => {
+    fetchPostings();
+  }, [searchMethodChanged]);
+
   const fetchPostings = () => {
     setIsLoading(true);
 
-    fetch(postings_url, {
+    console.log(searchMethod);
+    const url = searchMethod === 'COMMUNITY' ? postings_url : generateRadiusUrl();
+
+    fetch(url, {
       method: 'GET',
       headers: {
         'Accept': 'application/json',
@@ -39,9 +46,22 @@ const UserPostingListScreen = props => {
       .then(json => {
         updatePostings(json);
       })
+      .catch(error => console.log(error))
       .finally(() => {
         setIsLoading(false)
       });
+  };
+
+  const generateRadiusUrl = () => {
+    const loc = user.profile.home_location;
+    const longitude = loc.slice(loc.indexOf('(') + 1, loc.lastIndexOf(' '));
+    const latitude = loc.slice(loc.lastIndexOf(' ') + 1, loc.indexOf(')'));
+
+    let url = postings_url;
+    url += '?longitude=' + longitude + '&latitude=' + latitude + '&radius=' + searchRadius;
+    console.log(url);
+
+    return url;
   };
 
   const handleSearch = text => {

--- a/react-native/screens/UserPostingListScreen.js
+++ b/react-native/screens/UserPostingListScreen.js
@@ -28,7 +28,7 @@ const UserPostingListScreen = props => {
 
 
   useEffect(() => {
-    filterPostings(postings);
+    filterPostings();
   }, [postings]);
 
   const fetchPostings = () => {
@@ -51,7 +51,7 @@ const UserPostingListScreen = props => {
       });
   };
 
-  const filterPostings = postings => {
+  const filterPostings = () => {
     let filtered = postings.filter(posting => {
       return posting.owner === user.user.id;
     });
@@ -64,16 +64,16 @@ const UserPostingListScreen = props => {
   const handleSearch = text => {
     setSearchText(text);
 
-    let filteredPostings = postings.filter(posting =>
+    let filtered = filteredPostings.filter(posting =>
       posting.title.toLowerCase().includes(text.toLowerCase())
     );
 
-    setSearchPostings(filteredPostings);
+    setSearchPostings(filtered);
   };
 
   const handleClearSearchInput = () => {
     setSearchText('');
-    setSearchPostings(postings);
+    setSearchPostings(filteredPostings);
     searchInputRef.current.clear();
   };
 

--- a/react-native/screens/UserPostingListScreen.js
+++ b/react-native/screens/UserPostingListScreen.js
@@ -20,16 +20,10 @@ const UserPostingListScreen = props => {
   const { navigation } = props;
   const { user, postings, updatePostings } = useContext(AuthContext);
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [filteredPostings, setFilteredPostings] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
   const [searchPostings, setSearchPostings] = useState([]);
   const [searchText, setSearchText] = useState('');
   const searchInputRef = useRef(null);
-
-
-  useEffect(() => {
-    filterPostings();
-  }, [postings]);
 
   const fetchPostings = () => {
     setIsLoading(true);
@@ -83,6 +77,7 @@ const UserPostingListScreen = props => {
             navigation={navigation}
             isLoading={isLoading}
             onRefresh={fetchPostings}
+            filterType='USER'
           />
 
   return(


### PR DESCRIPTION
## Additions
1) Adds postings to app context so that all list screens share the same list of postings instead of fetching and maintaining their own copies
2) This allows changes to be updated reflected automatically in the lists, say when a posting is flagged, a user won't have to 'Pull to Refresh' on a list in order to see the changes ~~(except when changing search method)~~
3) Add Settings page where there is an option to change from Community Based search to Radius based search.  It defaults to community based search but when toggled, a radius slider will appear to allow the user to select the radius they want to search in (from 1 to 50 miles). ~~Going back to the Home screen, the user can pull to refresh to see the new set of Postings~~
Edit: When Search method is changed, the postings list should be automatically refreshed.
4) Add button in Title Bar of Profile Screen to update the user's location to their current location.
5) Add a map to Profile Screen so user knows where their home location is set.

## To Note
- Currently all List Screens share the same list of postings so if the Search method is changed then the shared list of postings will change. This means that navigating to 'My Postings' or 'Saved Postings' may not show the same postings (or anything at all) if the user is using the Radius method and those postings are outside their range.
- I hope to change this in the future but for now it will have to do.

- Please check to make sure these new features work as expected and in particular, that there are no crashes or unexpected behavior.


## Issues closed
closes #231 
closes #218 